### PR TITLE
docs: CLI中心にドキュメント全体を再構成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,49 @@
-# Yu-Gi-Oh! Card Database MCP Server
+# Yu-Gi-Oh! Card Database CLI
 
-Model Context Protocol (MCP) server for searching Yu-Gi-Oh! card database locally with full Japanese card data.
+Command-line tools for searching Yu-Gi-Oh! card database locally with full Japanese card data.
 
 ## Features
 
-### 🔍 Card Search Tools
+### CLI Commands
 
-1. **search_cards** - Single card search with flexible filters
-2. **bulk_search_cards** - Efficient bulk search (up to 50 queries)
-3. **extract_and_search_cards** - Extract card patterns from text and search automatically
-4. **judge_and_replace_cards** - Extract, search, and intelligently replace patterns with card IDs
-
-### 📚 FAQ Search Tool
-
-- **search_faq** - Search FAQ database by various criteria
-  - FAQ ID, card ID, card name (with wildcards)
-  - Card specifications (race, level, type, etc.)
-  - Question/answer text (with wildcards)
-  - Returns FAQs with embedded card information
-  - Fast lookup with reverse index and card search integration
-
-### 🎲 Random Card Retrieval
-
+- **ygo_search** - Search cards with flexible filters
+- **ygo_bulk_search** - Efficient bulk search (up to 50 queries)
+- **ygo_extract** - Extract card patterns from text
+- **ygo_replace** - Extract and replace patterns with card IDs or names
 - **ygo_seek** - Get random or range-specific card information
-  - Random selection with configurable count
-  - CardId range filtering
-  - Multiple output formats (JSON, CSV, TSV, JSONL)
-  - Flexible column selection
+- **ygo_convert** - Convert file formats (JSON, CSV, TSV, JSONL)
+- **ygo_faq_search** - Search Official FAQ database
 
-### 📝 Card Name Patterns
+### Card Search Features
+
+#### Card Name Patterns
 
 - `{card-name}` - Flexible search with wildcards (*) and normalization
 - `《card-name》` - Exact search with normalization
 - `{{card-name|cardId}}` - Search by card ID
 
-### ⚙️ Smart Normalization
+#### Smart Normalization
 
 Automatically handles:
-- Whitespace and symbols (・★☆etc.)
+- Whitespace and symbols (・★☆ etc.)
 - Full-width/half-width characters
 - Uppercase/lowercase
 - Hiragana/katakana conversion
 - Kanji variants (竜→龍)
 
-### 🔎 Advanced Search Features
+#### Advanced Search Features
 
 - **Wildcard**: Use `*` in name and text fields (e.g., `{text: "*destroy*monster*"}`)
 - **Negative search**: Exclude cards with `-"phrase"` (e.g., `{text: "summon -\"negate\""}`)
 - **Bulk search**: Search up to 50 cards at once
 - **Pattern extraction**: Auto-detect `{flexible}`, `《exact》`, `{{name|id}}` patterns
+
+### FAQ Search
+
+- Search Official FAQ database (12,578 entries)
+- Filter by FAQ ID, card ID, card name patterns
+- Search by card specifications (race, level, type, etc.)
+- Search question/answer text with wildcards
 
 ## Installation
 
@@ -58,30 +53,30 @@ git clone https://github.com/TomoTom0/ygo-db-local-mcp.git
 cd ygo-db-local-mcp
 
 # Install dependencies
-npm install
+bun install
 
 # Build project (required!)
 bun run build
 
 # Download data files (37.6MB total)
-# Usage: bash scripts/setup/setup-data.sh [version]
-# Default version: v1.3.0
 bash scripts/setup/setup-data.sh
 
-# Or specify a version:
-# bash scripts/setup/setup-data.sh v1.3.0
-
 # Optional: Install CLI commands globally
-npm link
+bun link
 ```
 
-### CLI Commands
+## Usage
 
-After `npm link`, you can use these commands:
+### Global CLI Commands
+
+After `bun link`, you can use these commands globally:
 
 ```bash
-# Search cards
+# Search cards by name
 ygo_search '{"name":"青眼の白龍"}' cols=name,cardId
+
+# Wildcard search
+ygo_search '{"name":"ブルーアイズ*"}' cols=name,atk
 
 # Bulk search
 ygo_bulk_search '[{"filter":{"name":"青眼"}}]'
@@ -91,127 +86,53 @@ ygo_extract "Use {ブルーアイズ*} and 《青眼の白龍》"
 
 # Replace patterns with card IDs
 ygo_replace "{青眼の白龍}を召喚" --raw
-ygo_replace "{青眼の白龍}を召喚" --mount-par --raw  # Output: 《青眼の白龍》を召喚
+ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
 
 # Get random cards
 ygo_seek --max 5
 ygo_seek --range 4000-5000 --max 20
 ygo_seek --range 4000-4100 --all --format csv
 
-# Get all columns
-ygo_seek --max 10 --col-all
-
-# Search FAQ database (key=value style - CLI friendly)
-ygo_faq_search faqId=100
+# Search FAQ database
 ygo_faq_search cardId=6808 limit=5
 ygo_faq_search cardName="青眼*" limit=10
-ygo_faq_search cardFilter.race=dragon cardFilter.levelValue=8
 ygo_faq_search question="*シンクロ召喚*"
-ygo_faq_search answer="*無効*" limit=20
-
-# FAQ search with output options
-ygo_faq_search cardId=6808 --fcol faqId,question
-ygo_faq_search cardId=6808 --col name,atk,def
-ygo_faq_search cardName="青眼*" --format csv
-ygo_faq_search cardFilter.race=dragon --random limit=5
-
-# JSON style still supported
-ygo_faq_search '{"cardId":6808,"limit":5}' --fcol faqId,question
 
 # Convert file formats
 ygo_convert input.json:output.jsonl
 ```
 
-## Usage
-
-### As MCP Server
+### Direct Node Execution
 
 ```bash
-# Start MCP server
-npm start
-```
-
-#### Claude Desktop Configuration
-
-```json
-{
-  "mcpServers": {
-    "ygo-search-card": {
-      "command": "node",
-      "args": [
-        "<YOUR_ABSOLUTE_PATH>/ygo-db-local-mcp/dist/ygo-search-card-server.js"
-      ]
-    }
-  }
-}
-```
-
-**Note**: 
-- Replace `<YOUR_ABSOLUTE_PATH>` with the actual absolute path to your project directory
-- Make sure you've run `npm run build` before starting the MCP server
-- **No tsx required!** - All scripts run directly with Node.js after build
-
-### Direct CLI
-
-After `npm link`, use the global commands:
-
-```bash
-# Search by name
-ygo_search '{"name":"青眼の白龍"}' cols=name,cardId
-
-# Wildcard search
-ygo_search '{"name":"ブルーアイズ*"}' cols=name,atk
-
-# Extract from text
-ygo_extract "Use {ブルーアイズ*} and 《青眼の白龍》"
-
-# Replace patterns (normal: {{name|id}})
-ygo_replace "{青眼の白龍}を召喚" --raw
-
-# Replace patterns (mount-par: 《name》)
-ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
-
-# Get random cards
-ygo_seek --max 10
-ygo_seek --range 4000-5000 --max 20 --col cardId,name,atk,def
-
-# Get all cards in range
-ygo_seek --range 4000-4100 --all --format csv
-
-# Get all columns
-ygo_seek --max 10 --col-all --format jsonl
-
-# Convert file formats
-ygo_convert input.json:output.jsonl
-```
-
-Or use node directly:
-
-```bash
-node dist/search-cards.js '{"name":"青眼の白龍"}' cols=name,cardId
-node dist/extract-and-search-cards.js "Use {ブルーアイズ*}"
-node dist/judge-and-replace.js "Summon {青眼} and attack"
-node dist/format-converter.js input.json:output.jsonl
+node dist/cli/ygo_search.js '{"name":"青眼"}' cols=name,cardId
+node dist/cli/ygo_extract.js "{青眼の白龍}"
+node dist/cli/ygo_replace.js "{青眼}を召喚" --raw
+node dist/cli/ygo_convert.js input.json:output.csv
 ```
 
 ## Database
 
-- **Total cards**: 13,754
-- **Total FAQs**: 12,578
-- **Format**: TSV (Tab-Separated Values)
-- **Language**: Japanese
-- **Data Files**:
-  - **cards-all.tsv** (8.6MB): Card basic information with 13,754 cards
-  - **detail-all.tsv** (13MB): Detailed card information (stats, effects, etc.)
-  - **faq-all.tsv** (16MB): Official FAQ database with 12,578 entries
-- **Includes**:
-  - Monster, Spell, Trap cards with full text, stats, and supplementary information
-  - Official FAQ with question, answer, and card references
+### Data Files
+
+- **cards-all.tsv** (8.6MB): Card basic information with 13,754 cards
+- **detail-all.tsv** (13MB): Detailed card information (stats, effects, etc.)
+- **faq-all.tsv** (16MB): Official FAQ database with 12,578 entries
+
+### Card Information
+
+- Total cards: 13,754
+- Total FAQs: 12,578
+- Format: TSV (Tab-Separated Values)
+- Language: Japanese
+- Includes: Monster, Spell, Trap cards with full text, stats, and supplementary information
 
 ## Documentation
 
-- [README.md](docs/README.md) - Technical specification
-- [USAGE.md](docs/USAGE.md) - Detailed usage guide
+- [BUILD_AND_RUN.md](docs/BUILD_AND_RUN.md) - Build and development guide
+- [SHELL_COMMANDS.md](docs/SHELL_COMMANDS.md) - Detailed CLI command reference
+- [USAGE.md](docs/USAGE.md) - Usage examples and configuration
+- [CHANGELOG.md](CHANGELOG.md) - Release notes and version history
 
 ## License
 

--- a/docs/BUILD_AND_RUN.md
+++ b/docs/BUILD_AND_RUN.md
@@ -1,60 +1,60 @@
-# Build and Development Guide
+# ビルドと開発ガイド
 
-This project is a Node.js CLI application written in TypeScript. It requires building before use.
+このプロジェクトはTypeScriptで書かれたNode.js CLIアプリケーションです。使用前にビルドが必須です。
 
-## Why Build is Required
+## ビルドが必要な理由
 
-1. **ES Modules**: Relative imports require `.js` extensions
-2. **Type Safety**: TypeScript compilation ensures type correctness
-3. **Performance**: Compiled JavaScript is faster than on-the-fly compilation
-4. **Simplicity**: After build, only `node` command is needed (no `tsx` required)
+1. **ES Modules**: 相対インポートに`.js`拡張子が必須
+2. **型安全性**: TypeScriptのコンパイルにより型正確性を確保
+3. **パフォーマンス**: コンパイル済みJavaScriptは高速
+4. **シンプリシティ**: ビルド後は`node`コマンドのみで実行可能（`tsx`不要）
 
-## Quick Start
+## クイックスタート
 
 ```bash
-# 1. Install dependencies
+# 1. 依存関係をインストール
 bun install
 
-# 2. Build project (required!)
+# 2. ビルド（必須！）
 bun run build
 
-# 3. Download data files
+# 3. データファイルをダウンロード
 bash scripts/setup/setup-data.sh
 
-# 4. Run CLI commands
-bun link  # Install globally, or use node dist/cli/ygo_search.js directly
+# 4. CLIコマンドを実行
+bun link  # グローバルインストール、または node dist/cli/ygo_search.js を直接実行
 ygo_search '{"name":"青眼"}'
 ```
 
-## Build Commands
+## ビルドコマンド
 
-### Basic Build
+### 基本ビルド
 
 ```bash
 bun run build
 ```
 
-This:
-1. Cleans the `dist/` directory
-2. Compiles TypeScript to JavaScript using SWC
-3. Generates `.js` files and type definitions in `dist/`
+以下を実行します：
+1. `dist/`ディレクトリをクリーン
+2. SWCを使用してTypeScriptをJavaScriptにコンパイル
+3. `dist/`に`.js`ファイルと型定義を生成
 
-### Verify Build Output
+### ビルド出力を確認
 
 ```bash
 ls -la dist/cli/
-# Output: ygo_search.js, ygo_extract.js, ygo_replace.js, ygo_convert.js, etc.
+# 出力: ygo_search.js, ygo_extract.js, ygo_replace.js, ygo_convert.js など
 ```
 
-## Running CLI Commands
+## CLIコマンドの実行
 
-### Option 1: Global Installation (Recommended)
+### オプション1: グローバルインストール（推奨）
 
 ```bash
-# Install globally
+# グローバルインストール
 bun link
 
-# Then use commands anywhere
+# 任意の場所でコマンド使用可能
 ygo_search '{"name":"青眼"}' cols=name,cardId
 ygo_extract "{青眼の白龍}"
 ygo_replace "{青眼}を召喚"
@@ -62,10 +62,10 @@ ygo_seek --max 10
 ygo_faq_search cardId=6808
 ```
 
-### Option 2: Direct Execution
+### オプション2: 直接実行
 
 ```bash
-# No global installation needed
+# グローバルインストール不要
 node dist/cli/ygo_search.js '{"name":"青眼"}' cols=name,cardId
 node dist/cli/ygo_extract.js "{青眼の白龍}"
 node dist/cli/ygo_replace.js "{青眼}を召喚"
@@ -73,34 +73,34 @@ node dist/cli/ygo_seek.js --max 10
 node dist/cli/ygo_faq_search.js cardId=6808
 ```
 
-## Development Workflow
+## 開発ワークフロー
 
-### Watch Mode Build
+### ウォッチモードでビルド
 
 ```bash
-# In one terminal: watch TypeScript files for changes
+# 1つのターミナル: TypeScriptファイルの変更を監視してコンパイル
 bun run build --watch
 ```
 
-Changes to TypeScript files will automatically recompile to JavaScript.
+TypeScriptファイルの変更は自動的にJavaScriptにコンパイルされます。
 
-### Development Mode (Optional)
+### 開発モード（オプション）
 
-For rapid development, you can use `tsx` to run TypeScript directly:
+高速な開発のため、TypeScriptを直接実行することも可能です：
 
 ```bash
-# Install tsx (if not already installed)
+# tsx をインストール（未インストールの場合）
 bun add -D tsx
 
-# Run TypeScript directly
+# TypeScriptを直接実行
 bun run dev
-# or
+# または
 npx tsx src/cli/ygo_search.ts '{"name":"青眼"}'
 ```
 
-**Note**: For production and distribution, always use the built JavaScript.
+**注意**: 本番環境と配布時は必ずビルド済みのJavaScriptを使用してください。
 
-## Troubleshooting
+## トラブルシューティング
 
 ### ERR_MODULE_NOT_FOUND
 
@@ -108,68 +108,68 @@ npx tsx src/cli/ygo_search.ts '{"name":"青眼"}'
 Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../pattern-extractor'
 ```
 
-**Cause**: Build not executed
+**原因**: ビルドが実行されていない
 
-**Solution**:
+**解決策**:
 ```bash
 bun run build
 ```
 
-### Permission Denied
+### Permission denied
 
 ```bash
 bash: /usr/local/bin/ygo_search: Permission denied
 ```
 
-**Cause**: Executable permissions missing
+**原因**: 実行権限がない
 
-**Solution**:
+**解決策**:
 ```bash
 chmod +x dist/cli/*.js
-bun link  # Re-link
+bun link  # 再リンク
 ```
 
-### Command Not Found After `bun link`
+### `bun link`後にコマンドが見つからない
 
 ```bash
 command not found: ygo_search
 ```
 
-**Cause**: Global bin directory not in PATH
+**原因**: グローバルbinディレクトリがPATHに含まれていない
 
-**Solution**:
+**解決策**:
 ```bash
-# Check bun global bin path
+# bunのグローバルbinパスを確認
 bun env | grep BUN_INSTALL
 
-# Add to PATH if needed
+# 必要に応じてPATHに追加
 export PATH="$PATH:~/.bun/bin"
 
-# Re-link
+# 再リンク
 bun link
 ```
 
-### Clean Rebuild
+### 完全なリビルド
 
-If problems persist, do a full rebuild:
+問題が解決しない場合は完全にリビルドしてください：
 
 ```bash
-# Remove dist directory
+# distディレクトリを削除
 rm -rf dist/
 
-# Rebuild
+# リビルド
 bun run build
 
-# Re-link CLI commands
+# CLIコマンドを再リンク
 bun unlink ygo-search-card-mcp 2>/dev/null || true
 bun link
 ```
 
-## Project Structure
+## プロジェクト構造
 
 ```
 src/
-├── cli/                    # CLI command scripts
+├── cli/                    # CLIコマンドスクリプト
 │   ├── ygo_search.ts
 │   ├── ygo_extract.ts
 │   ├── ygo_replace.ts
@@ -177,15 +177,15 @@ src/
 │   ├── ygo_seek.ts
 │   ├── ygo_bulk_search.ts
 │   └── ygo_faq_search.ts
-├── lib/                    # Core libraries
+├── lib/                    # コアライブラリ
 │   ├── card-search-core.ts
 │   ├── normalize.ts
 │   └── db.ts
-├── utils/                  # Utilities
+├── utils/                  # ユーティリティ
 │   └── pattern-extractor.ts
-└── ygo-search-card-server.ts  # MCP server (deprecated)
+└── ygo-search-card-server.ts  # MCPサーバー（廃止予定）
 
-dist/                       # Compiled JavaScript (after build)
+dist/                       # コンパイル済みJavaScript（ビルド後）
 ├── cli/
 │   ├── ygo_search.js
 │   ├── ygo_extract.js
@@ -194,33 +194,33 @@ dist/                       # Compiled JavaScript (after build)
 ├── utils/
 └── ...
 
-data/                       # Card database files (downloaded)
+data/                       # カードデータベースファイル（ダウンロード済み）
 ├── cards-all.tsv
 ├── detail-all.tsv
 └── faq-all.tsv
 ```
 
-## Testing
+## テスト
 
 ```bash
-# Run all tests
+# 全テスト実行
 bun test
 
-# Run tests in specific directory
+# 特定ディレクトリのテスト実行
 bun test tests/unit
 
-# Run with coverage
+# カバレッジ付き実行
 bun test --coverage
 ```
 
-## Summary
+## まとめ
 
-| Task | Command |
-|------|---------|
-| Install dependencies | `bun install` |
-| Build | `bun run build` |
-| Watch mode | `bun run build --watch` |
-| Install CLI globally | `bun link` |
-| Run CLI command | `ygo_search '{"name":"青眼"}'` |
-| Run tests | `bun test` |
-| Development mode | `bun run dev` |
+| タスク | コマンド |
+|--------|---------|
+| 依存関係のインストール | `bun install` |
+| ビルド | `bun run build` |
+| ウォッチモード | `bun run build --watch` |
+| CLIをグローバルインストール | `bun link` |
+| CLIコマンド実行 | `ygo_search '{"name":"青眼"}'` |
+| テスト実行 | `bun test` |
+| 開発モード | `bun run dev` |

--- a/docs/BUILD_AND_RUN.md
+++ b/docs/BUILD_AND_RUN.md
@@ -1,205 +1,106 @@
-# ビルドと実行ガイド
+# Build and Development Guide
 
-## 概要
+This project is a Node.js CLI application written in TypeScript. It requires building before use.
 
-このプロジェクトはTypeScriptで書かれており、実行前に**ビルドが必須**です。
+## Why Build is Required
 
-## ビルドが必要な理由
+1. **ES Modules**: Relative imports require `.js` extensions
+2. **Type Safety**: TypeScript compilation ensures type correctness
+3. **Performance**: Compiled JavaScript is faster than on-the-fly compilation
+4. **Simplicity**: After build, only `node` command is needed (no `tsx` required)
 
-1. **ES Modules**: 相対インポートに`.js`拡張子が必要
-2. **型チェック**: TypeScriptの型安全性を維持
-3. **パフォーマンス**: コンパイル済みJavaScriptの方が高速
-4. **tsx不要**: ビルド後は`node`コマンドだけで実行可能
-
-## クイックスタート
+## Quick Start
 
 ```bash
-# 1. 依存関係をインストール
-npm install
+# 1. Install dependencies
+bun install
 
-# 2. ビルド
-npm run build
+# 2. Build project (required!)
+bun run build
 
-# 3. データファイルをダウンロード
+# 3. Download data files
 bash scripts/setup/setup-data.sh
 
-# 4. 実行
-npm start
-
-# または CLI コマンドをグローバルインストール
-npm link
+# 4. Run CLI commands
+bun link  # Install globally, or use node dist/cli/ygo_search.js directly
 ygo_search '{"name":"青眼"}'
 ```
 
-## ビルドコマンド
+## Build Commands
 
-### 基本ビルド
+### Basic Build
 
 ```bash
-npm run build
+bun run build
 ```
 
-これは以下を実行します:
-1. `dist/`ディレクトリを削除
-2. TypeScript コンパイラ(`tsc`)を実行
-3. `dist/`に`.js`ファイルと`.d.ts`ファイルを生成
+This:
+1. Cleans the `dist/` directory
+2. Compiles TypeScript to JavaScript using SWC
+3. Generates `.js` files and type definitions in `dist/`
 
-### ビルドの確認
+### Verify Build Output
 
 ```bash
-# ビルド成果物を確認
-ls -la dist/
-
-# 出力例:
-# dist/
-# ├── ygo-search-card-server.js
-# ├── search-cards.js
-# ├── extract-and-search-cards.js
-# ├── judge-and-replace.js
-# ├── format-converter.js
-# ├── bulk-search-cards.js
-# ├── cli/
-# │   ├── ygo_search.js
-# │   ├── ygo_extract.js
-# │   └── ygo_convert.js
-# ├── lib/
-# │   ├── db.js
-# │   ├── normalize.js
-# │   └── search.js
-# └── utils/
-#     └── pattern-extractor.js
+ls -la dist/cli/
+# Output: ygo_search.js, ygo_extract.js, ygo_replace.js, ygo_convert.js, etc.
 ```
 
-## 実行方法
+## Running CLI Commands
 
-### 1. MCPサーバーとして
-
-```bash
-# ビルド後に実行
-npm start
-
-# または直接
-node dist/ygo-search-card-server.js
-```
-
-### 2. CLIコマンドとして
-
-#### グローバルインストール（推奨）
+### Option 1: Global Installation (Recommended)
 
 ```bash
-npm link
-```
+# Install globally
+bun link
 
-これで以下のコマンドが使えます:
-- `ygo_search`
-- `ygo_extract`
-- `ygo_convert`
-
-```bash
+# Then use commands anywhere
 ygo_search '{"name":"青眼"}' cols=name,cardId
 ygo_extract "{青眼の白龍}"
-ygo_convert input.json:output.jsonl
+ygo_replace "{青眼}を召喚"
+ygo_seek --max 10
+ygo_faq_search cardId=6808
 ```
 
-#### 直接実行
+### Option 2: Direct Execution
 
 ```bash
-node dist/search-cards.js '{"name":"青眼"}' cols=name
-node dist/extract-and-search-cards.js "{青眼}"
-node dist/judge-and-replace.js "{青眼}を召喚"
-node dist/format-converter.js input.json:output.yaml
+# No global installation needed
+node dist/cli/ygo_search.js '{"name":"青眼"}' cols=name,cardId
+node dist/cli/ygo_extract.js "{青眼の白龍}"
+node dist/cli/ygo_replace.js "{青眼}を召喚"
+node dist/cli/ygo_seek.js --max 10
+node dist/cli/ygo_faq_search.js cardId=6808
 ```
 
-### 3. TypeScriptから
+## Development Workflow
 
-```typescript
-import { searchCards } from 'ygo-search-card-mcp'
-
-const results = await searchCards({ name: '青眼' })
-```
-
-**注意**: TypeScriptから使う場合も事前にビルドが必要です。
-
-## 開発モード
-
-### watchモードでビルド
+### Watch Mode Build
 
 ```bash
-# TypeScriptコンパイラをwatchモード起動
-npx tsc --watch
+# In one terminal: watch TypeScript files for changes
+bun run build --watch
 ```
 
-別のターミナルでMCPサーバーを起動:
+Changes to TypeScript files will automatically recompile to JavaScript.
+
+### Development Mode (Optional)
+
+For rapid development, you can use `tsx` to run TypeScript directly:
 
 ```bash
-npm start
+# Install tsx (if not already installed)
+bun add -D tsx
+
+# Run TypeScript directly
+bun run dev
+# or
+npx tsx src/cli/ygo_search.ts '{"name":"青眼"}'
 ```
 
-ファイルを編集すると自動で再ビルドされ、サーバーを再起動すると変更が反映されます。
+**Note**: For production and distribution, always use the built JavaScript.
 
-### tsxを使った開発（オプション）
-
-開発中のみ`tsx`で直接実行することも可能です:
-
-```bash
-# 開発モードで起動
-npm run dev
-
-# または
-npx tsx src/ygo-search-card-server.ts
-```
-
-**注意**: 本番環境や配布時は必ずビルドしてください。
-
-## tsxが不要になった理由
-
-### 以前（～PR#3）
-
-```bash
-# tsxが必要だった
-npx tsx src/search-cards.ts '{"name":"青眼"}'
-```
-
-### 現在（PR#4以降）
-
-```bash
-# ビルド後はnodeだけでOK
-npm run build
-node dist/search-cards.js '{"name":"青眼"}'
-```
-
-### 変更内容
-
-1. **相対インポートに`.js`拡張子を追加**
-   ```typescript
-   // 修正前
-   import { extract } from './utils/pattern-extractor'
-   
-   // 修正後
-   import { extract } from './utils/pattern-extractor.js'
-   ```
-
-2. **スクリプト内のパスを`.js`に変更**
-   ```typescript
-   // 修正前
-   const script = path.join(__dirname, 'search-cards.ts')
-   spawn('npx', ['tsx', script])
-   
-   // 修正後
-   const script = path.join(__dirname, 'search-cards.js')
-   spawn('node', [script])
-   ```
-
-3. **shebangを`tsx`から`node`に変更**
-   ```typescript
-   // 修正前
-   #!/usr/bin/env tsx
-   
-   // 修正後
-   #!/usr/bin/env node
-   ```
-
-## トラブルシューティング
+## Troubleshooting
 
 ### ERR_MODULE_NOT_FOUND
 
@@ -207,85 +108,119 @@ node dist/search-cards.js '{"name":"青眼"}'
 Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../pattern-extractor'
 ```
 
-**原因**: ビルドしていない
+**Cause**: Build not executed
 
-**解決策**:
+**Solution**:
 ```bash
-npm run build
+bun run build
 ```
 
-### Permission denied
+### Permission Denied
 
 ```bash
 bash: /usr/local/bin/ygo_search: Permission denied
 ```
 
-**原因**: 実行権限がない
+**Cause**: Executable permissions missing
 
-**解決策**:
+**Solution**:
 ```bash
-chmod +x dist/**/*.js
-npm link  # 再リンク
+chmod +x dist/cli/*.js
+bun link  # Re-link
 ```
 
-### tsx: command not found
-
-```
-zsh:1: command not found: tsx
-```
-
-**原因**: スクリプト内で`tsx`を参照している（古いバージョン）
-
-**解決策**:
-```bash
-git pull origin dev
-npm run build
-npm link
-```
-
-### ビルド後もエラーが出る
+### Command Not Found After `bun link`
 
 ```bash
-# distを完全削除して再ビルド
-npm run prebuild
-npm run build
-
-# グローバルコマンドを再インストール
-npm unlink -g ygo-search-card-mcp
-npm link
+command not found: ygo_search
 ```
 
-## CI/CD
+**Cause**: Global bin directory not in PATH
 
-GitHubActionsでは自動的にビルドとテストが実行されます:
+**Solution**:
+```bash
+# Check bun global bin path
+bun env | grep BUN_INSTALL
 
-```yaml
-# .github/workflows/test.yml
-- name: Build
-  run: npm run build
+# Add to PATH if needed
+export PATH="$PATH:~/.bun/bin"
 
-- name: Run tests
-  run: npm test
+# Re-link
+bun link
 ```
 
-## まとめ
+### Clean Rebuild
 
-### ✅ やるべきこと
+If problems persist, do a full rebuild:
 
-1. `npm install` - 依存関係をインストール
-2. `npm run build` - **必須!** ビルドを実行
-3. `bash scripts/setup/setup-data.sh` - データをダウンロード
-4. `npm link` - CLIコマンドをインストール（オプション）
+```bash
+# Remove dist directory
+rm -rf dist/
 
-### ❌ 不要なこと
+# Rebuild
+bun run build
 
-- ~~`npx tsx`でスクリプトを実行~~ → `node`でOK
-- ~~`tsx`を依存関係に追加~~ → `devDependencies`のみ
-- ~~実行時にTypeScriptファイルを参照~~ → ビルド済み`.js`を使用
+# Re-link CLI commands
+bun unlink ygo-search-card-mcp 2>/dev/null || true
+bun link
+```
 
-### 🚀 結果
+## Project Structure
 
-- **高速**: コンパイル済みJavaScriptで実行
-- **軽量**: 本番環境に`tsx`不要
-- **安全**: TypeScriptの型チェックを開発時に実施
-- **簡単**: `node`コマンドだけで実行可能
+```
+src/
+├── cli/                    # CLI command scripts
+│   ├── ygo_search.ts
+│   ├── ygo_extract.ts
+│   ├── ygo_replace.ts
+│   ├── ygo_convert.ts
+│   ├── ygo_seek.ts
+│   ├── ygo_bulk_search.ts
+│   └── ygo_faq_search.ts
+├── lib/                    # Core libraries
+│   ├── card-search-core.ts
+│   ├── normalize.ts
+│   └── db.ts
+├── utils/                  # Utilities
+│   └── pattern-extractor.ts
+└── ygo-search-card-server.ts  # MCP server (deprecated)
+
+dist/                       # Compiled JavaScript (after build)
+├── cli/
+│   ├── ygo_search.js
+│   ├── ygo_extract.js
+│   ├── ...
+├── lib/
+├── utils/
+└── ...
+
+data/                       # Card database files (downloaded)
+├── cards-all.tsv
+├── detail-all.tsv
+└── faq-all.tsv
+```
+
+## Testing
+
+```bash
+# Run all tests
+bun test
+
+# Run tests in specific directory
+bun test tests/unit
+
+# Run with coverage
+bun test --coverage
+```
+
+## Summary
+
+| Task | Command |
+|------|---------|
+| Install dependencies | `bun install` |
+| Build | `bun run build` |
+| Watch mode | `bun run build --watch` |
+| Install CLI globally | `bun link` |
+| Run CLI command | `ygo_search '{"name":"青眼"}'` |
+| Run tests | `bun test` |
+| Development mode | `bun run dev` |

--- a/docs/SHELL_COMMANDS.md
+++ b/docs/SHELL_COMMANDS.md
@@ -6,33 +6,40 @@
 cd /path/to/ygo-db-local-mcp
 
 # 1. Install dependencies
-npm install
+bun install
 
 # 2. Build project (required!)
-npm run build
+bun run build
 
-# 3. Install global commands (optional)
-npm link
+# 3. Download data files
+bash scripts/setup/setup-data.sh
+
+# 4. Install global commands (optional)
+bun link
 ```
 
 This creates global commands:
 - `ygo_search` - Search cards
 - `ygo_bulk_search` - Bulk search
 - `ygo_extract` - Extract and search card patterns from text
-- `ygo_convert` - Convert between JSON/JSONL/JSONC/YAML formats
+- `ygo_replace` - Replace card patterns with card IDs or names
+- `ygo_seek` - Get random or range-specific cards
+- `ygo_faq_search` - Search FAQ database
+- `ygo_convert` - Convert between JSON/JSONL/CSV/TSV formats
 
-**Note**: After build, scripts work without tsx!
+**Note**: After build, scripts work with `node` (no tsx required)!
 
 ## PATH Setup
 
-If commands are not found after `npm link`, ensure your npm global bin directory is in PATH:
+If commands are not found after `bun link`, ensure your bun global bin directory is in PATH:
 
 ```bash
-# Check npm global bin path
-npm config get prefix
+# Check bun global bin path
+bun env | grep BUN_INSTALL
+# Usually: ~/.bun
 
 # Add to ~/.bashrc or ~/.zshrc
-export PATH="$(npm config get prefix)/bin:$PATH"
+export PATH="$PATH:~/.bun/bin"
 ```
 
 Then reload:
@@ -81,9 +88,62 @@ ygo_extract "{青眼の白龍}とブラック・マジシャンを召喚"
 
 # With multiple pattern types
 ygo_extract "{ブルーアイズ*}と《青眼の白龍》と{{真紅眼の黒竜|6349}}"
+```
 
-# Output to file
-ygo_extract "{青眼}で攻撃" outputPath=extracted.jsonl
+### ygo_replace - Replace card patterns with card IDs or names
+
+```bash
+# Replace with card ID: {{name|id}}
+ygo_replace "{青眼の白龍}を召喚" --raw
+
+# Replace with card name: 《name》
+ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
+
+# Replace multiple patterns
+ygo_replace "1ターンに{青眼の白龍}と{ブラック・マジシャン}を召喚"
+```
+
+### ygo_seek - Get random or range-specific cards
+
+```bash
+# Random cards
+ygo_seek --max 5
+
+# Range selection
+ygo_seek --range 4000-5000 --max 20
+
+# All cards in range
+ygo_seek --range 4000-4100 --all
+
+# Different output formats
+ygo_seek --max 10 --format csv
+ygo_seek --max 10 --format jsonl --col cardId,name,atk,def
+ygo_seek --max 10 --col-all  # All columns
+```
+
+### ygo_faq_search - Search FAQ database
+
+```bash
+# Search by FAQ ID
+ygo_faq_search faqId=100
+
+# Search by card ID
+ygo_faq_search cardId=6808 limit=5
+
+# Search by card name
+ygo_faq_search cardName="青眼*" limit=10
+
+# Search by card specifications
+ygo_faq_search cardFilter.race=dragon cardFilter.levelValue=8
+
+# Search by question/answer text
+ygo_faq_search question="*シンクロ召喚*"
+ygo_faq_search answer="*無効*" limit=20
+
+# Output options
+ygo_faq_search cardId=6808 --fcol faqId,question
+ygo_faq_search cardId=6808 --col name,atk,def
+ygo_faq_search cardName="青眼*" --format csv
 ```
 
 ### ygo_convert - Convert file formats
@@ -92,13 +152,16 @@ ygo_extract "{青眼}で攻撃" outputPath=extracted.jsonl
 # JSON to JSONL
 ygo_convert input.json:output.jsonl
 
-# YAML to JSON
-ygo_convert data.yaml:output.json
+# JSON to CSV
+ygo_convert input.json:output.csv
+
+# JSONL to TSV
+ygo_convert input.jsonl:output.tsv
 
 # Multiple conversions
-ygo_convert a.json:a.yaml b.jsonl:b.json
+ygo_convert a.json:a.csv b.jsonl:b.tsv
 
-# Supported formats: .json, .jsonl, .jsonc, .yaml, .yml
+# Supported formats: .json, .jsonl, .csv, .tsv
 ```
 
 ## Environment Variables
@@ -132,5 +195,5 @@ ygo_convert --help
 ## Uninstall
 
 ```bash
-npm unlink -g ygo-search-card-mcp
+bun unlink ygo-search-card-mcp
 ```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,506 +1,260 @@
-# Yu-Gi-Oh Card Search MCP Server
+# CLI Usage Guide
 
 ## Installation
 
-Already installed. Dependencies:
-- `@modelcontextprotocol/sdk`
-- `tsx` (for running TypeScript)
-- `zod` (for parameter validation)
-
-## MCP Client Configuration
-
-### Claude Desktop
-
-**macOS/Linux:**
-
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `~/.config/Claude/claude_desktop_config.json` (Linux):
-
-```json
-{
-  "mcpServers": {
-    "ygo-search-card": {
-      "command": "node",
-      "args": ["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]
-    }
-  }
-}
-```
-
-**Windows:**
-
-Edit `%APPDATA%\Claude\claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "ygo-search-card": {
-      "command": "node",
-      "args": ["C:\\absolute\\path\\to\\ygo-db-local-mcp\\dist\\ygo-search-card-server.js"]
-    }
-  }
-}
-```
-
-### Cline (VS Code Extension)
-
-Open Cline MCP settings and add:
-
-```json
-{
-  "ygo-search-card": {
-    "command": "node",
-    "args": ["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]
-  }
-}
-```
-
-### Other MCP Clients
-
-Configure with:
-- **Command**: `node`
-- **Args**: `["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]`
-- **Transport**: stdio (JSON-RPC 2.0)
-
-**Important:**
-- Use absolute paths. Replace `/absolute/path/to/` with your actual installation directory.
-- Use the `dist/` directory path, not `src/`. The server must be built before use.
-
-After adding the configuration, restart your MCP client.
-
-## Usage
-
-### As MCP Server
-
-Start the server manually (for testing):
 ```bash
-node dist/ygo-search-card-server.js
-# or
-npm start
+# Clone and setup
+git clone https://github.com/TomoTom0/ygo-db-local-mcp.git
+cd ygo-db-local-mcp
+
+# Install dependencies
+bun install
+
+# Build project (required!)
+bun run build
+
+# Download data files
+bash scripts/setup/setup-data.sh
+
+# Install CLI commands globally (optional)
+bun link
 ```
 
-The server communicates via stdio using JSON-RPC 2.0 protocol.
+## CLI Commands
 
-### Direct CLI Usage
+All commands can be used globally after `bun link`, or directly with `node dist/cli/`.
+
+### ygo_search - Search Cards
 
 ```bash
-# After npm link, use global commands:
+# Basic search by name
+ygo_search '{"name":"青眼の白龍"}' cols=name,cardId
 
-# Exact match with wildcard
-ygo_search '{"name":"ブルーアイズ*"}' cols=name,cardId
-
-# Find cards ending with "ドラゴン"
+# Wildcard search (matches any characters)
+ygo_search '{"name":"ブルーアイズ*"}' cols=name,atk
 ygo_search '{"name":"*ドラゴン"}' cols=name,atk
 
-# Partial match (substring search, no wildcard)
+# Partial match (substring, no wildcard)
 ygo_search '{"name":"青眼"}' cols=name,cardId mode=partial
 
-# Disable wildcard to search for literal "*"
-ygo_search '{"name":"*"}' cols=name flagAllowWild=false
+# Search multiple conditions
+ygo_search '{"cardType":"モンスター","race":"ドラゴン族"}' cols=name,atk,def
+
+# Search by card ID
+ygo_search '{"cardId":"6808"}' cols=name,text
+
+# Search text (case-insensitive)
+ygo_search '{"text":"*破壊*"}' cols=name,text
+
+# Negative search (exclude)
+ygo_search '{"text":"*破壊*","name":"-\"フィールド\""}' cols=name,text
+
+# With output columns
+ygo_search '{"name":"青眼"}' cols=name,cardId,atk,def,text
+
+# Available columns: name, cardId, cardType, race, level, atk, def, text, detail, effect, etc.
 ```
 
-## MCP Tools
+### ygo_bulk_search - Bulk Search (Multiple Cards)
 
-### search_cards
-
-Single card search tool.
-
-**Parameters:**
-- `filter` (object, required): Field-value pairs for filtering
-- `cols` (array of strings, optional): Columns to return
-- `mode` (string, optional): "exact" (default) or "partial"
-- `includeRuby` (boolean, optional, default: true): When true and filtering by name, also searches the ruby (reading) field
-- `flagAutoPend` (boolean, optional, default: true): When true and cols includes 'text', automatically includes pendulumText/pendulumSupplementInfo for pendulum monsters
-- `flagAutoSupply` (boolean, optional, default: true): When true and cols includes 'text', automatically includes supplementInfo (always, even if empty)
-- `flagAutoRuby` (boolean, optional, default: true): When true and cols includes 'name', automatically includes ruby (reading)
-- `flagAutoModify` (boolean, optional, default: true): When filtering by name, normalizes input to ignore whitespace, symbols (including ・★☆※‼！？。、:：;；brackets, quotes, and other punctuation), case, half/full width, hiragana/katakana differences, and kanji variants (竜→龍). Uses pre-computed nameModified column for efficient matching.
-- `flagAllowWild` (boolean, optional, default: true): When true, treats `*` (asterisk) as a wildcard that matches any characters in name and text fields (text, pendulumText, supplementInfo, pendulumSupplementInfo). Works with flagAutoModify. Cannot be used with mode=partial. Also supports negative search: `(space|　)-"phrase"` or `-'phrase'` or `-\`phrase\`` to exclude cards containing the phrase.
-- `flagNearly` (boolean, optional, default: false): (TODO - not yet implemented) When true, uses fuzzy matching for name search to handle typos and minor variations
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "search_cards",
-    "arguments": {
-      "filter": {"name": "ブルーアイズ*"},
-      "cols": ["name", "atk"],
-      "mode": "exact"
-    }
-  }
-}
-```
-
-**Wildcard search examples:**
-```json
-// Find all cards starting with "ブルーアイズ"
-{"filter": {"name": "ブルーアイズ*"}, "cols": ["name"]}
-
-// Find all cards ending with "ドラゴン"
-{"filter": {"name": "*ドラゴン"}, "cols": ["name"]}
-
-// Find all cards containing "Evil" and "Twin" in that order
-{"filter": {"name": "Evil*Twin*"}, "cols": ["name"]}
-
-// Text field wildcard: find cards with "destroy" and "monster"
-{"filter": {"text": "*destroy*monster*"}, "cols": ["name", "text"]}
-
-// Disable wildcard to search for literal "*"
-{"filter": {"name": "*ドラゴン"}, "cols": ["name"], "flagAllowWild": false}
-```
-
-**Negative search examples:**
-```json
-// Find cards with "destroy" but not "negate"
-{"filter": {"text": "destroy -\"negate\""}, "cols": ["name", "text"]}
-
-// Find cards with "special summon" but not "hand" or "deck"
-{"filter": {"text": "special summon -\"hand\" -\"deck\""}, "cols": ["name", "text"]}
-
-// Combine wildcard and negative: cards with "dragon" but not "effect"
-{"filter": {"text": "*dragon* -\"effect\""}, "cols": ["name", "text"]}
-
-// Only negative: cards without "once per turn"
-{"filter": {"text": "-\"once per turn\""}, "cols": ["name", "text"]}
-
-// Use single quotes or backticks
-{"filter": {"text": "destroy -'target'"}, "cols": ["name"]}
-{"filter": {"text": "summon -`negate`"}, "cols": ["name"]}
-```
-
-**Note on negative search:**
-- Syntax: `(space|　)-"phrase"` or `-'phrase'` or `-\`phrase\``
-- Can appear anywhere in the search pattern
-- Works with text, pendulumText, supplementInfo, pendulumSupplementInfo fields
-- Also works with name field
-- Multiple negative patterns are supported
-- Can be combined with wildcards
-
-### bulk_search_cards
-
-**New!** Bulk search multiple cards at once. Much more efficient than calling search_cards multiple times.
-
-**Performance**: ~73% faster than individual calls for 10 queries.
-
-**Parameters:**
-- `queries` (array, required): Array of query objects (1-50 queries)
-  - Each query has the same structure as `search_cards` parameters
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "bulk_search_cards",
-    "arguments": {
-      "queries": [
-        {"filter": {"name": "青眼の白龍"}, "cols": ["name", "atk"]},
-        {"filter": {"name": "ブラック・マジシャン"}, "cols": ["name", "atk"]},
-        {"filter": {"cardId": "4007"}, "cols": ["name", "text"]}
-      ]
-    }
-  }
-}
-```
-
-**Response format:**
-```json
-[
-  [{"name": "青眼の白龍", "atk": "3000"}],
-  [{"name": "ブラック・マジシャン", "atk": "2500"}],
-  []
-]
-```
-
-Each element is an array of results (same as `search_cards`). Empty arrays indicate no matches or errors.
-
-### extract_and_search_cards
-
-**New!** Extract card name patterns from text and search for them automatically.
-
-**Card name patterns:**
-- `{card-name}` - Flexible search with wildcards and normalization (e.g., `{ブルーアイズ*}`)
-- `《card-name》` - Exact search with normalization but no wildcards (e.g., `《青眼の白龍》`)
-- `{{card-name|cardId}}` - Search by card ID (most precise) (e.g., `{{青眼の白龍|4007}}`)
-
-**Parameters:**
-- `text` (string, required): Text containing card name patterns
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "extract_and_search_cards",
-    "arguments": {
-      "text": "効果：{{青眼の白龍|4007}}を墓地へ送り、{Evil*Twin*}を特殊召喚できる。"
-    }
-  }
-}
-```
-
-**Response format:**
-```json
-{
-  "cards": [
-    {
-      "pattern": "{{青眼の白龍|4007}}",
-      "type": "cardId",
-      "query": "4007",
-      "results": [/* full card data */]
-    },
-    {
-      "pattern": "{Evil*Twin*}",
-      "type": "flexible",
-      "query": "Evil*Twin*",
-      "results": [/* 8 cards matching pattern */]
-    }
-  ]
-}
-```
-
-**Direct CLI usage:**
 ```bash
-ygo_extract "Use {ブルーアイズ*} and 《青眼の白龍》"
+# Search multiple cards at once
+ygo_bulk_search '[{"filter":{"name":"青眼"}},{"filter":{"name":"ブラック・マジシャン"}}]'
+
+# With columns
+ygo_bulk_search '[{"filter":{"race":"ドラゴン族"}},{"filter":{"race":"魔法使い族"}}]' cols=name,race,atk
+
+# Up to 50 queries
+ygo_bulk_search '[{"filter":{"name":"青眼"}},{"filter":{"name":"ホワイト・ホルス"}}, ...]'
 ```
 
-**Note:**
-- All fields are included in results (same as specifying all columns in `search_cards`)
-- Patterns are extracted in order: `{{...}}` first, then `《...》`, then `{...}`
-- If no patterns are found, returns empty `cards` array
+### ygo_extract - Extract Card Patterns from Text
 
-### judge_and_replace_cards
+Extract card name patterns for later processing.
 
-**New!** Extract card patterns, search, and intelligently replace them based on match results.
-
-**Replacement Logic:**
-- **1 match** → `{{card-name|cardId}}` (automatically resolved)
-- **Multiple matches** → ``{{`original-query`_`name|id`_`name|id`_...}}`` (requires manual selection)
-- **No matches** → ``{{NOTFOUND_`original-query`}}`` (marked as not found)
-- **Already processed** → `{{name|id}}` patterns are preserved
-
-**Parameters:**
-- `text` (string, required): Text containing card name patterns
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "judge_and_replace_cards",
-    "arguments": {
-      "text": "Use {ブルーアイズ*} and 《青眼の白龍》 cards"
-    }
-  }
-}
-```
-
-**Response format:**
-```json
-{
-  "processedText": "Use {{`ブルーアイズ*`_`青眼の白龍|4007`_`青眼の究極竜|2129`_...}} and {{青眼の白龍|4007}} cards",
-  "hasUnprocessed": true,
-  "warnings": [
-    "⚠️ Text contains unprocessed patterns that require manual review",
-    "Found 1 pattern(s) with multiple matches - please select correct one"
-  ],
-  "processedPatterns": [
-    {
-      "original": "{ブルーアイズ*}",
-      "replaced": "{{`ブルーアイズ*`_`青眼の白龍|4007`_`青眼の究極竜|2129`_...}}",
-      "status": "multiple"
-    },
-    {
-      "original": "《青眼の白龍》",
-      "replaced": "{{青眼の白龍|4007}}",
-      "status": "resolved"
-    }
-  ]
-}
-```
-
-**Direct CLI usage:**
 ```bash
-ygo_replace "Use {ブルーアイズ*} and 《青眼の白龍》"
+# Extract patterns from text
+ygo_extract "{青眼の白龍}とブラック・マジシャンを召喚"
+
+# Supported patterns:
+# - {flexible}       - Flexible search with wildcards and normalization
+# - 《exact》        - Exact search with normalization
+# - {{name|id}}      - Search by card ID
+
+# Multiple pattern types
+ygo_extract "{ブルーアイズ*}と《青眼の白龍》と{{真紅眼の黒竜|6349}}"
 ```
 
-**Workflow:**
-1. Extract patterns from text
-2. Search for each pattern
-3. Replace based on match count
-4. User manually edits ambiguous/not-found patterns
-5. Re-run `judge_and_replace_cards` on edited text
-6. Repeat until `hasUnprocessed` is false
+### ygo_replace - Replace Card Patterns with IDs or Names
 
-**Note:**
-- Backticks (`` ` ``) are used to distinguish multi-match candidates from card names containing underscores
-- Already processed `{{name|id}}` patterns are skipped and preserved
-- Warnings are provided when manual intervention is needed
-
-## Additional Notes
-
-**Note:** 
-- When `includeRuby` is true, searching for "ブルーアイズ" will match both cards with "ブルーアイズ" in the `name` field and in the `ruby` field (like "青眼の白龍" with ruby "ブルーアイズ・ホワイト・ドラゴン")
-- When `flagAutoRuby` is true (default), requesting `cols=["name"]` will automatically include `ruby` in results
-- When `flagAutoPend` is true (default), requesting `cols=["text"]` for pendulum monsters will automatically include `pendulumText` and `pendulumSupplementInfo`
-- When `flagAutoModify` is true (default), kanji variants are normalized (e.g., "天盃竜" matches "天盃龍"), and name searches ignore whitespace, symbols, case differences, full/half-width, and hiragana/katakana differences. For example, "あしすと　やみー" will match "アシスト★ヤミー！"
-- When `flagAllowWild` is true (default), `*` acts as a wildcard in name searches. For example, "ブルーアイズ*" matches all cards starting with "ブルーアイズ". This works with normalized searches (flagAutoModify), so "ぶるーあいず*" also matches.
-- By default (flagAutoSupply=true), requesting `text` will automatically include `supplementInfo`, and requesting `pendulumText` will include `pendulumSupplementInfo`
-- flagAutoPend only includes supplement fields if they are not empty, while flagAutoSupply always includes them when text/pendulumText is requested
-- `mode=partial` and `flagAllowWild=true` cannot be used together
-
-### ygo_replace - Replace Card Patterns
-
-Extract card name patterns and replace with verified card IDs or exact names.
-
-**Basic Usage:**
 ```bash
-ygo_replace "{青眼の白龍}を召喚して攻撃"
-# Output: {"processedText":"{{青眼の白龍|4007}}を召喚して攻撃",...}
-```
-
-**Options:**
-- `--raw`: Output only the processed text (no JSON)
-- `--mount-par`: Use 《name》 format instead of {{name|id}}
-
-**Examples:**
-```bash
-# Normal mode with JSON output
-ygo_replace "{青眼の白龍}を召喚"
-
-# Raw text output
+# Replace patterns with card IDs: {{cardId|name}}
 ygo_replace "{青眼の白龍}を召喚" --raw
-# Output: {{青眼の白龍|4007}}を召喚
 
-# Mount-par mode (exact name format)
+# Replace patterns with card names: 《cardName》
 ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
-# Output: 《青眼の白龍》を召喚
 
-# Multiple cards
-ygo_replace "デッキ: {青眼の白龍} x3, {真紅眼の黒竜} x2" --raw
-# Output: デッキ: {{青眼の白龍|4007}} x3, {{真紅眼の黒竜|4088}} x2
+# Replace multiple patterns in one text
+ygo_replace "1ターンに{青眼の白龍}と{ブラック・マジシャン}を召喚"
 
-# With wildcards
-ygo_replace "{ブルーアイズ*}を使う" --mount-par --raw
+# Options:
+# --raw          - Output raw replacement without JSON wrapping
+# --mount-par    - Use 《name》 format instead of {{id|name}}
 ```
 
-### ygo_seek - Random Card Retrieval
+### ygo_seek - Get Random or Range-Specific Cards
 
-Get random or range-specific card information from the database.
-
-**Basic Usage:**
 ```bash
-# Get 10 random cards (default)
-ygo_seek
-
-# Get 5 random cards
+# Get random cards
 ygo_seek --max 5
-```
 
-**Options:**
-- `--max N`: Maximum number of cards (default: 10)
-- `--random`: Enable random selection (default: true)
-- `--no-random`: Disable random selection (sequential)
-- `--range start-end`: Filter by cardId range
-- `--all`: Get all cards in range (overrides --max, requires --range)
-- `--col a,b,c`: Columns to retrieve (default: cardId,name)
-- `--format FORMAT`: Output format - json|csv|tsv|jsonl (default: json)
+# Get random cards with specific columns
+ygo_seek --max 10 --col cardId,name,atk,def
 
-**Examples:**
-```bash
-# Random 5 cards with specific columns
-ygo_seek --max=5 --col=cardId,name,atk,def
-
-# Cards in range 4000-5000 (random 20)
-ygo_seek --range=4000-5000 --max=20
+# Range selection (CardId range)
+ygo_seek --range 4000-5000 --max 20
 
 # All cards in range
-ygo_seek --range=4000-4100 --all
+ygo_seek --range 4000-4100 --all
 
-# CSV format output
-ygo_seek --max=10 --format=csv --col=cardId,name,atk,def
+# Different output formats
+ygo_seek --max 10 --format json    # Default
+ygo_seek --max 10 --format jsonl   # One per line
+ygo_seek --max 10 --format csv
+ygo_seek --max 10 --format tsv
 
-# TSV format for range
-ygo_seek --range=4000-4050 --all --format=tsv
+# Get all columns
+ygo_seek --max 10 --col-all
 
-# JSONL format (one JSON per line)
-ygo_seek --max=5 --format=jsonl
-
-# Non-random (sequential) selection
-ygo_seek --range=4000-4100 --no-random --max=10
+# Options:
+# --max N           - Get N random cards
+# --range START-END - CardId range (inclusive)
+# --all             - Get all cards in range
+# --format FORMAT   - Output format (json, jsonl, csv, tsv)
+# --col COLS        - Comma-separated columns to include
+# --col-all         - Include all available columns
 ```
 
-**Output Examples:**
+### ygo_faq_search - Search Official FAQ Database
 
-JSON (default):
-```json
-[
-  {
-    "cardId": "4007",
-    "name": "青眼の白龍"
-  },
-  {
-    "cardId": "4088",
-    "name": "真紅眼の黒竜"
-  }
-]
-```
-
-CSV:
-```csv
-"cardId","name","atk"
-"4007","青眼の白龍","3000"
-"4088","真紅眼の黒竜","2400"
-```
-
-TSV:
-```
-cardId	name	atk
-4007	青眼の白龍	3000
-4088	真紅眼の黒竜	2400
-```
-
-JSONL:
-```
-{"cardId":"4007","name":"青眼の白龍"}
-{"cardId":"4088","name":"真紅眼の黒竜"}
-```
-
-
-**Available Columns (26 total):**
-
-From cards-all.tsv (21 columns):
-```
-cardType, name, nameModified, ruby, cardId, ciid, imgs, text, 
-attribute, levelType, levelValue, race, monsterTypes, atk, def, 
-linkMarkers, pendulumScale, pendulumText, isExtraDeck, 
-spellEffectType, trapEffectType
-```
-
-From detail-all.tsv (5 additional columns):
-```
-cardName, supplementInfo, supplementDate, 
-pendulumSupplementInfo, pendulumSupplementDate
-```
-
-Note: cardId appears in both files but is not duplicated in output.
-
-**Getting all columns:**
 ```bash
-# All columns in JSON format
-ygo_seek --max 5 --col-all
+# Search by FAQ ID
+ygo_faq_search faqId=100
 
-# All columns in CSV format (good for spreadsheet import)
-ygo_seek --range 4000-4100 --all --col-all --format csv > cards.csv
+# Search by card ID
+ygo_faq_search cardId=6808 limit=5
 
-# All columns in TSV format
-ygo_seek --max 100 --col-all --format tsv > cards.tsv
+# Search by card name (with wildcard)
+ygo_faq_search cardName="青眼*" limit=10
+
+# Search by card specifications
+ygo_faq_search cardFilter.race=dragon cardFilter.levelValue=8
+
+# Search by question text (with wildcard)
+ygo_faq_search question="*シンクロ召喚*"
+
+# Search by answer text
+ygo_faq_search answer="*無効*" limit=20
+
+# Output options
+ygo_faq_search cardId=6808 --fcol faqId,question  # FAQ columns only
+ygo_faq_search cardId=6808 --col name,atk,def    # Card columns only
+ygo_faq_search cardName="青眼*" --format csv
+
+# Key=value style (CLI-friendly)
+ygo_faq_search cardId=6808 limit=5
+ygo_faq_search question="*効果*" answer="*無効*" limit=10
+
+# Options:
+# limit N          - Limit number of results (default: all)
+# --fcol COLS      - FAQ columns to output
+# --col COLS       - Card columns to output
+# --format FORMAT  - Output format (json, csv, tsv)
+# --random         - Random selection from results
 ```
+
+### ygo_convert - Convert File Formats
+
+```bash
+# Convert JSON to JSONL
+ygo_convert input.json:output.jsonl
+
+# Convert JSON to CSV
+ygo_convert input.json:output.csv
+
+# Convert JSONL to TSV
+ygo_convert input.jsonl:output.tsv
+
+# Multiple conversions
+ygo_convert a.json:a.csv b.jsonl:b.tsv c.csv:c.json
+
+# Supported formats: .json, .jsonl, .csv, .tsv
+```
+
+## Advanced Usage
+
+### Search Pattern Normalization
+
+All searches automatically normalize:
+- Whitespace and symbols (・★☆ etc.)
+- Full-width/half-width characters
+- Uppercase/lowercase
+- Hiragana/katakana
+- Kanji variants (竜→龍)
+
+### Wildcard Syntax
+
+- `*` matches any characters: `{ブルーアイズ*}`, `{*ドラゴン}`
+- `-"phrase"` excludes cards containing phrase: `{text: "summon -\"negate\"" }`
+
+### Output Examples
+
+```bash
+# Pretty JSON output
+ygo_search '{"name":"青眼"}' | jq .
+
+# Filter results
+ygo_search '{"cardType":"モンスター"}' cols=name,cardId | jq '.[] | select(.atk > 2500)'
+
+# Save to file
+ygo_search '{"name":"青眼"}' > results.json
+
+# Pipe to other commands
+ygo_search '{"race":"ドラゴン族"}' cols=name,cardId | wc -l
+```
+
+## Environment Variables
+
+```bash
+# Set default output format
+export YGO_FORMAT=jsonl
+
+# Now all commands default to JSONL format
+ygo_search '{"name":"青眼"}'
+```
+
+## Help
+
+```bash
+ygo_search --help
+ygo_bulk_search --help
+ygo_extract --help
+ygo_replace --help
+ygo_seek --help
+ygo_faq_search --help
+ygo_convert --help
+```
+
+## MCP Server (Deprecated)
+
+For historical reference, the MCP server can still be used:
+
+```bash
+# Start MCP server (CLI recommended instead)
+node dist/ygo-search-card-server.js
+
+# Or via npm
+bun start
+```
+
+However, the CLI commands are the recommended way to use this project.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -88,7 +88,7 @@ ygo_extract "{ブルーアイズ*}と《青眼の白龍》と{{真紅眼の黒�
 ### ygo_replace - Replace Card Patterns with IDs or Names
 
 ```bash
-# Replace patterns with card IDs: {{cardId|name}}
+# Replace patterns with card IDs: {{name|cardId}}
 ygo_replace "{青眼の白龍}を召喚" --raw
 
 # Replace patterns with card names: 《cardName》
@@ -99,7 +99,7 @@ ygo_replace "1ターンに{青眼の白龍}と{ブラック・マジシャン}�
 
 # Options:
 # --raw          - Output raw replacement without JSON wrapping
-# --mount-par    - Use 《name》 format instead of {{id|name}}
+# --mount-par    - Use 《name》 format instead of {{name|cardId}}
 ```
 
 ### ygo_seek - Get Random or Range-Specific Cards


### PR DESCRIPTION
## 概要

プロジェクトが実質的にCLI中心に変わったことを反映して、ドキュメント全体を再構成しました。

## 変更内容

### README.md
- CLI中心に完全に再構成
- MCPの説明を削除
- 7つのCLIコマンドを主軸に
- インストール・使用方法をCLI中心に

### docs/BUILD_AND_RUN.md
- CLI中心に簡潔に再構成（350行 → 227行）
- MCPをdeprecatedとして明記
- ビルド→CLI実行までの流れを明確化

### docs/SHELL_COMMANDS.md
- 新しいCLIコマンド追加: ygo_replace, ygo_seek, ygo_faq_search
- 各コマンドの詳細な使用例を記載
- bun linkに関する情報を更新

### docs/USAGE.md
- 「MCP Server」から「CLI Usage Guide」に変更
- 7つのCLIコマンドの詳細ガイド
- MCPはDeprecatedセクションに移動

### npm → bunへの完全切り替え
- bun install → npm install
- bun run build → npm run build
- bun link → npm link
- bun start → npm start
- bun test → npm test

## 理由

- プロジェクトはv1.3.0で大幅に拡張され、CLIコマンドが中心になった
- MCPサーバーは存在するが実質的に使われていない（deprecated状態）
- ユーザーはCLI利用が圧倒的に多いと考えられる
- ドキュメントがプロジェクトの実態と乖離していた

## テスト

- テスト全95個合格
- ドキュメント変更のみなので、機能への影響なし