### PR TITLE
v1.3.0: CLI中心へのドキュメント再構成とリポジトリ統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.3.0] - 2025-12-18
+
+### Added
+- **FAQ Search Functionality**: New `search_faq` tool for searching Official FAQ database
+  - Search by FAQ ID, card ID, card name patterns
+  - Filter by card specifications (race, level, type, etc.)
+  - Search question/answer text with wildcards
+  - Returns FAQs with embedded card information
+  - Fast lookup with reverse index and card search integration
+  - New data file: `faq-all.tsv` (12,578 FAQs)
+- **ygo_seek Command**: Get random or range-specific card information
+  - Random selection with configurable count
+  - CardId range filtering
+  - Multiple output formats (JSON, CSV, TSV, JSONL)
+  - Flexible column selection
+  - `--col-all` option to retrieve all columns
+- **ygo_replace Command**: Extract, search, and intelligently replace patterns with card IDs or card names
+  - Supports `{flexible}`, `《exact》`, `{{name|id}}` patterns
+  - `--mount-par` option for replacing with 《card-name》 format
+- **ygo_extract Command**: Extract card name patterns from text
+  - Identifies `{flexible}`, `《exact》`, `{{name|id}}` patterns
+- **ygo_convert Command**: Convert file formats between JSON, CSV, TSV, and JSONL
+- **ygo_bulk_search Command**: Efficient bulk search (up to 50 queries)
+- **ygo_faq_search Command**: CLI command for FAQ search with key=value style arguments
+- **CardId Pattern Validation**: Automatic validation and correction of card names in `{{cardId|name}}` patterns
+- **--max and --sort Options**: Enhanced search capabilities for card selection
+- **File Output Save Feature**: Support for saving search results to files in various formats
+- **Shell Commands**: Global shell commands with `ygo_` prefix for CLI usage
+
+### Changed
+- **Package Manager Migration**: Moved from npm to bun for faster builds and package management
+- **Build System**: Updated to use SWC for faster TypeScript compilation
+- **CLI Architecture**: Reorganized CLI commands into dedicated modules under `dist/cli/`
+- **Data File Structure**: Expanded database to include FAQ information alongside card data
+
+### Fixed
+- **CLI Help Options**: Removed non-functional `outputPath` and `outputDir` options from help text
+- **Module Import Paths**: Fixed ES module import paths for Node.js compatibility
+- **HTTP Status Code Detection**: Improved error handling in setup script
+- **Error Handling**: Enhanced error messages and validation feedback across all tools
+- **Pattern Deduplication**: Optimized deduplication of processed patterns in output
+
+### Technical Improvements
+- **TypeScript Migration**: Converted MCP server to TypeScript for better type safety
+- **Schema Validation**: Added comprehensive JSON Schema documentation for all tools
+- **Test Coverage**: Expanded test suite to cover new features (95 tests passing)
+- **CI/CD Pipeline**: Improved GitHub Actions workflow for automated testing
+- **Documentation**: Enhanced documentation with detailed usage examples
+
+### Database Updates
+- **cards-all.tsv**: 13,754 cards (8.6MB)
+- **detail-all.tsv**: Detailed card information (13MB)
+- **faq-all.tsv**: 12,578 Official FAQs (16MB) - NEW
+
+## [v1.0.0] - 2025-11-17
+
+### Added
+- **Initial Release**
+- **search_cards**: Single card search with flexible filters
+- **bulk_search_cards**: Efficient bulk search (up to 50 queries)
+- **extract_and_search_cards**: Extract card patterns from text and search automatically
+- **judge_and_replace_cards**: Extract, search, and intelligently replace patterns with card IDs
+- **Card Name Patterns**:
+  - `{card-name}`: Flexible search with wildcards (*)
+  - `《card-name》`: Exact search with normalization
+  - `{{card-name|cardId}}`: Search by card ID
+- **Smart Normalization**: Automatic handling of whitespace, symbols, full-width/half-width, hiragana/katakana, and kanji variants
+- **Database**: 13,754 Yu-Gi-Oh! cards with full Japanese text and supplementary information
+
+### Data Files
+- **cards-all.tsv** (8.2MB): Card basic information
+- **detail-all.tsv** (13MB): Detailed card information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,79 +1,86 @@
-# Changelog
+# 変更履歴（Changelog）
 
-All notable changes to this project will be documented in this file.
+このファイルには、プロジェクトの全ての注目すべき変更が記録されます。
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+形式は [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
+このプロジェクトは [Semantic Versioning](https://semver.org/lang/ja/) に従っています。
 
 ## [v1.3.0] - 2025-12-18
 
-### Added
-- **FAQ Search Functionality**: New `search_faq` tool for searching Official FAQ database
-  - Search by FAQ ID, card ID, card name patterns
-  - Filter by card specifications (race, level, type, etc.)
-  - Search question/answer text with wildcards
-  - Returns FAQs with embedded card information
-  - Fast lookup with reverse index and card search integration
-  - New data file: `faq-all.tsv` (12,578 FAQs)
-- **ygo_seek Command**: Get random or range-specific card information
-  - Random selection with configurable count
-  - CardId range filtering
-  - Multiple output formats (JSON, CSV, TSV, JSONL)
-  - Flexible column selection
-  - `--col-all` option to retrieve all columns
-- **ygo_replace Command**: Extract, search, and intelligently replace patterns with card IDs or card names
-  - Supports `{flexible}`, `《exact》`, `{{name|id}}` patterns
-  - `--mount-par` option for replacing with 《card-name》 format
-- **ygo_extract Command**: Extract card name patterns from text
-  - Identifies `{flexible}`, `《exact》`, `{{name|id}}` patterns
-- **ygo_convert Command**: Convert file formats between JSON, CSV, TSV, and JSONL
-- **ygo_bulk_search Command**: Efficient bulk search (up to 50 queries)
-- **ygo_faq_search Command**: CLI command for FAQ search with key=value style arguments
-- **CardId Pattern Validation**: Automatic validation and correction of card names in `{{cardId|name}}` patterns
-- **--max and --sort Options**: Enhanced search capabilities for card selection
-- **File Output Save Feature**: Support for saving search results to files in various formats
-- **Shell Commands**: Global shell commands with `ygo_` prefix for CLI usage
+### 追加
 
-### Changed
-- **Package Manager Migration**: Moved from npm to bun for faster builds and package management
-- **Build System**: Updated to use SWC for faster TypeScript compilation
-- **CLI Architecture**: Reorganized CLI commands into dedicated modules under `dist/cli/`
-- **Data File Structure**: Expanded database to include FAQ information alongside card data
+- **FAQ検索機能**: 公式FAQデータベースを検索する新しい `search_faq` ツール
+  - FAQ ID、カード ID、カード名パターンで検索
+  - カードの仕様（種族、レベル、タイプなど）でフィルタリング
+  - 質問・回答テキストをワイルドカードで検索
+  - 埋め込まれたカード情報を含むFAQを返す
+  - 逆インデックスとカード検索統合による高速ルックアップ
+  - 新規データファイル: `faq-all.tsv`（12,578件のFAQ）
+- **ygo_seekコマンド**: ランダムまたは範囲指定のカード情報取得
+  - 設定可能な件数でのランダム選択
+  - カードID範囲でのフィルタリング
+  - 複数の出力形式（JSON、CSV、TSV、JSONL）
+  - 柔軟な列選択
+  - `--col-all` オプションで全列を取得可能
+- **ygo_replaceコマンド**: パターンを検出・検索し、カード ID またはカード名で知的に置換
+  - `{柔軟}`, `《正確》`, `{{名前|ID}}` パターンに対応
+  - `--mount-par` オプションで 《カード名》 形式で置換
+- **ygo_extractコマンド**: テキストからカード名パターンを抽出
+  - `{柔軟}`, `《正確》`, `{{名前|ID}}` パターンを識別
+- **ygo_convertコマンド**: JSON、CSV、TSV、JSONL 形式間でファイルを変換
+- **ygo_bulk_searchコマンド**: 効率的な一括検索（最大50クエリ）
+- **ygo_faq_searchコマンド**: CLI向けのキー=値形式でのFAQ検索コマンド
+- **カード ID パターン検証**: `{{cardId|name}}` パターン内のカード名を自動検証・修正
+- **--maxおよび--sortオプション**: カード選択機能の強化
+- **ファイル出力保存機能**: 検索結果を様々なフォーマットで保存可能
+- **シェルコマンド**: `ygo_` プレフィックス付きのグローバルシェルコマンド
 
-### Fixed
-- **CLI Help Options**: Removed non-functional `outputPath` and `outputDir` options from help text
-- **Module Import Paths**: Fixed ES module import paths for Node.js compatibility
-- **HTTP Status Code Detection**: Improved error handling in setup script
-- **Error Handling**: Enhanced error messages and validation feedback across all tools
-- **Pattern Deduplication**: Optimized deduplication of processed patterns in output
+### 変更
 
-### Technical Improvements
-- **TypeScript Migration**: Converted MCP server to TypeScript for better type safety
-- **Schema Validation**: Added comprehensive JSON Schema documentation for all tools
-- **Test Coverage**: Expanded test suite to cover new features (95 tests passing)
-- **CI/CD Pipeline**: Improved GitHub Actions workflow for automated testing
-- **Documentation**: Enhanced documentation with detailed usage examples
+- **パッケージマネージャー移行**: npm から bun へ移行（ビルド・パッケージ管理の高速化）
+- **ビルドシステム**: TypeScript コンパイル高速化のため SWC を使用
+- **CLI アーキテクチャ**: CLI コマンドを `dist/cli/` の専用モジュールに再編成
+- **データファイル構造**: FAQ情報をカードデータと共に統合
 
-### Database Updates
-- **cards-all.tsv**: 13,754 cards (8.6MB)
-- **detail-all.tsv**: Detailed card information (13MB)
-- **faq-all.tsv**: 12,578 Official FAQs (16MB) - NEW
+### 修正
+
+- **CLIヘルプオプション**: 機能しない `outputPath` および `outputDir` オプションをヘルプから削除
+- **モジュールインポートパス**: Node.js 互換性のための ES モジュールインポートパスを修正
+- **HTTP ステータスコード検出**: セットアップスクリプトのエラーハンドリングを改善
+- **エラーハンドリング**: 全ツールのエラーメッセージと検証フィードバックを強化
+- **パターン重複排除**: 出力内のパターン重複排除を最適化
+
+### 技術的改善
+
+- **TypeScript マイグレーション**: 型安全性向上のため MCP サーバーを TypeScript に変換
+- **スキーマ検証**: 全ツール用の包括的な JSON Schema ドキュメント追加
+- **テストカバレッジ**: テストスイートを拡張（95 テスト合格）
+- **CI/CD パイプライン**: GitHub Actions ワークフロー改善
+- **ドキュメント**: 詳細な使用例を含めドキュメント充実
+
+### データベース更新
+
+- **cards-all.tsv**: 13,754 枚のカード（8.6MB）
+- **detail-all.tsv**: カード詳細情報（13MB）
+- **faq-all.tsv**: 12,578 件の公式 FAQ（16MB）- 新規
 
 ## [v1.0.0] - 2025-11-17
 
-### Added
-- **Initial Release**
-- **search_cards**: Single card search with flexible filters
-- **bulk_search_cards**: Efficient bulk search (up to 50 queries)
-- **extract_and_search_cards**: Extract card patterns from text and search automatically
-- **judge_and_replace_cards**: Extract, search, and intelligently replace patterns with card IDs
-- **Card Name Patterns**:
-  - `{card-name}`: Flexible search with wildcards (*)
-  - `《card-name》`: Exact search with normalization
-  - `{{card-name|cardId}}`: Search by card ID
-- **Smart Normalization**: Automatic handling of whitespace, symbols, full-width/half-width, hiragana/katakana, and kanji variants
-- **Database**: 13,754 Yu-Gi-Oh! cards with full Japanese text and supplementary information
+### 追加
 
-### Data Files
-- **cards-all.tsv** (8.2MB): Card basic information
-- **detail-all.tsv** (13MB): Detailed card information
+- **初回リリース**
+- **search_cards**: 柔軟なフィルタで単一カード検索
+- **bulk_search_cards**: 効率的な一括検索（最大50クエリ）
+- **extract_and_search_cards**: テキストからカードパターンを抽出して自動検索
+- **judge_and_replace_cards**: パターンを検出・検索し、カード ID に知的に置換
+- **カード名パターン**:
+  - `{カード名}`: ワイルドカード (*) と正規化による柔軟検索
+  - `《カード名》`: 正規化による正確検索
+  - `{{カード名|cardId}}`: カード ID での検索
+- **スマート正規化**: 空白・記号、全角・半角、ひらがな・カタカナ、漢字異体字に自動対応
+- **データベース**: 完全な日本語テキストと補足情報を含む 13,754 枚の遊戯王カード
+
+### データファイル
+
+- **cards-all.tsv**（8.2MB）: カード基本情報
+- **detail-all.tsv**（13MB）: カード詳細情報

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Automatically handles:
 
 ```bash
 # Clone repository
-git clone https://github.com/TomoTom0/ygo-db-local-mcp.git
-cd ygo-db-local-mcp
+git clone https://github.com/TomoTom0/YuGiOh-Search-CLI.git
+cd YuGiOh-Search-CLI
 
 # Install dependencies
 bun install

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ cd ygo-db-local-mcp
 npm install
 
 # Build project (required!)
-npm run build
+bun run build
 
-# Download data files (21.2MB total)
+# Download data files (37.6MB total)
 # Usage: bash scripts/setup/setup-data.sh [version]
-# Default version: v1.0.0
+# Default version: v1.3.0
 bash scripts/setup/setup-data.sh
 
 # Or specify a version:
-# bash scripts/setup/setup-data.sh v1.0.0
+# bash scripts/setup/setup-data.sh v1.3.0
 
 # Optional: Install CLI commands globally
 npm link
@@ -200,7 +200,11 @@ node dist/format-converter.js input.json:output.jsonl
 - **Total FAQs**: 12,578
 - **Format**: TSV (Tab-Separated Values)
 - **Language**: Japanese
-- **Includes**: 
+- **Data Files**:
+  - **cards-all.tsv** (8.6MB): Card basic information with 13,754 cards
+  - **detail-all.tsv** (13MB): Detailed card information (stats, effects, etc.)
+  - **faq-all.tsv** (16MB): Official FAQ database with 12,578 entries
+- **Includes**:
   - Monster, Spell, Trap cards with full text, stats, and supplementary information
   - Official FAQ with question, answer, and card references
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,49 @@
-# Yu-Gi-Oh! Card Database MCP Server
+# Yu-Gi-Oh! Card Database CLI
 
-Model Context Protocol (MCP) server for searching Yu-Gi-Oh! card database locally with full Japanese card data.
+Command-line tools for searching Yu-Gi-Oh! card database locally with full Japanese card data.
 
 ## Features
 
-### 🔍 Card Search Tools
+### CLI Commands
 
-1. **search_cards** - Single card search with flexible filters
-2. **bulk_search_cards** - Efficient bulk search (up to 50 queries)
-3. **extract_and_search_cards** - Extract card patterns from text and search automatically
-4. **judge_and_replace_cards** - Extract, search, and intelligently replace patterns with card IDs
-
-### 📚 FAQ Search Tool
-
-- **search_faq** - Search FAQ database by various criteria
-  - FAQ ID, card ID, card name (with wildcards)
-  - Card specifications (race, level, type, etc.)
-  - Question/answer text (with wildcards)
-  - Returns FAQs with embedded card information
-  - Fast lookup with reverse index and card search integration
-
-### 🎲 Random Card Retrieval
-
+- **ygo_search** - Search cards with flexible filters
+- **ygo_bulk_search** - Efficient bulk search (up to 50 queries)
+- **ygo_extract** - Extract card patterns from text
+- **ygo_replace** - Extract and replace patterns with card IDs or names
 - **ygo_seek** - Get random or range-specific card information
-  - Random selection with configurable count
-  - CardId range filtering
-  - Multiple output formats (JSON, CSV, TSV, JSONL)
-  - Flexible column selection
+- **ygo_convert** - Convert file formats (JSON, CSV, TSV, JSONL)
+- **ygo_faq_search** - Search Official FAQ database
 
-### 📝 Card Name Patterns
+### Card Search Features
+
+#### Card Name Patterns
 
 - `{card-name}` - Flexible search with wildcards (*) and normalization
 - `《card-name》` - Exact search with normalization
 - `{{card-name|cardId}}` - Search by card ID
 
-### ⚙️ Smart Normalization
+#### Smart Normalization
 
 Automatically handles:
-- Whitespace and symbols (・★☆etc.)
+- Whitespace and symbols (・★☆ etc.)
 - Full-width/half-width characters
 - Uppercase/lowercase
 - Hiragana/katakana conversion
 - Kanji variants (竜→龍)
 
-### 🔎 Advanced Search Features
+#### Advanced Search Features
 
 - **Wildcard**: Use `*` in name and text fields (e.g., `{text: "*destroy*monster*"}`)
 - **Negative search**: Exclude cards with `-"phrase"` (e.g., `{text: "summon -\"negate\""}`)
 - **Bulk search**: Search up to 50 cards at once
 - **Pattern extraction**: Auto-detect `{flexible}`, `《exact》`, `{{name|id}}` patterns
+
+### FAQ Search
+
+- Search Official FAQ database (12,578 entries)
+- Filter by FAQ ID, card ID, card name patterns
+- Search by card specifications (race, level, type, etc.)
+- Search question/answer text with wildcards
 
 ## Installation
 
@@ -58,30 +53,30 @@ git clone https://github.com/TomoTom0/ygo-db-local-mcp.git
 cd ygo-db-local-mcp
 
 # Install dependencies
-npm install
+bun install
 
 # Build project (required!)
 bun run build
 
 # Download data files (37.6MB total)
-# Usage: bash scripts/setup/setup-data.sh [version]
-# Default version: v1.3.0
 bash scripts/setup/setup-data.sh
 
-# Or specify a version:
-# bash scripts/setup/setup-data.sh v1.3.0
-
 # Optional: Install CLI commands globally
-npm link
+bun link
 ```
 
-### CLI Commands
+## Usage
 
-After `npm link`, you can use these commands:
+### Global CLI Commands
+
+After `bun link`, you can use these commands globally:
 
 ```bash
-# Search cards
+# Search cards by name
 ygo_search '{"name":"青眼の白龍"}' cols=name,cardId
+
+# Wildcard search
+ygo_search '{"name":"ブルーアイズ*"}' cols=name,atk
 
 # Bulk search
 ygo_bulk_search '[{"filter":{"name":"青眼"}}]'
@@ -91,127 +86,53 @@ ygo_extract "Use {ブルーアイズ*} and 《青眼の白龍》"
 
 # Replace patterns with card IDs
 ygo_replace "{青眼の白龍}を召喚" --raw
-ygo_replace "{青眼の白龍}を召喚" --mount-par --raw  # Output: 《青眼の白龍》を召喚
+ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
 
 # Get random cards
 ygo_seek --max 5
 ygo_seek --range 4000-5000 --max 20
 ygo_seek --range 4000-4100 --all --format csv
 
-# Get all columns
-ygo_seek --max 10 --col-all
-
-# Search FAQ database (key=value style - CLI friendly)
-ygo_faq_search faqId=100
+# Search FAQ database
 ygo_faq_search cardId=6808 limit=5
 ygo_faq_search cardName="青眼*" limit=10
-ygo_faq_search cardFilter.race=dragon cardFilter.levelValue=8
 ygo_faq_search question="*シンクロ召喚*"
-ygo_faq_search answer="*無効*" limit=20
-
-# FAQ search with output options
-ygo_faq_search cardId=6808 --fcol faqId,question
-ygo_faq_search cardId=6808 --col name,atk,def
-ygo_faq_search cardName="青眼*" --format csv
-ygo_faq_search cardFilter.race=dragon --random limit=5
-
-# JSON style still supported
-ygo_faq_search '{"cardId":6808,"limit":5}' --fcol faqId,question
 
 # Convert file formats
 ygo_convert input.json:output.jsonl
 ```
 
-## Usage
-
-### As MCP Server
+### Direct Node Execution
 
 ```bash
-# Start MCP server
-npm start
-```
-
-#### Claude Desktop Configuration
-
-```json
-{
-  "mcpServers": {
-    "ygo-search-card": {
-      "command": "node",
-      "args": [
-        "<YOUR_ABSOLUTE_PATH>/ygo-db-local-mcp/dist/ygo-search-card-server.js"
-      ]
-    }
-  }
-}
-```
-
-**Note**: 
-- Replace `<YOUR_ABSOLUTE_PATH>` with the actual absolute path to your project directory
-- Make sure you've run `npm run build` before starting the MCP server
-- **No tsx required!** - All scripts run directly with Node.js after build
-
-### Direct CLI
-
-After `npm link`, use the global commands:
-
-```bash
-# Search by name
-ygo_search '{"name":"青眼の白龍"}' cols=name,cardId
-
-# Wildcard search
-ygo_search '{"name":"ブルーアイズ*"}' cols=name,atk
-
-# Extract from text
-ygo_extract "Use {ブルーアイズ*} and 《青眼の白龍》"
-
-# Replace patterns (normal: {{name|id}})
-ygo_replace "{青眼の白龍}を召喚" --raw
-
-# Replace patterns (mount-par: 《name》)
-ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
-
-# Get random cards
-ygo_seek --max 10
-ygo_seek --range 4000-5000 --max 20 --col cardId,name,atk,def
-
-# Get all cards in range
-ygo_seek --range 4000-4100 --all --format csv
-
-# Get all columns
-ygo_seek --max 10 --col-all --format jsonl
-
-# Convert file formats
-ygo_convert input.json:output.jsonl
-```
-
-Or use node directly:
-
-```bash
-node dist/search-cards.js '{"name":"青眼の白龍"}' cols=name,cardId
-node dist/extract-and-search-cards.js "Use {ブルーアイズ*}"
-node dist/judge-and-replace.js "Summon {青眼} and attack"
-node dist/format-converter.js input.json:output.jsonl
+node dist/cli/ygo_search.js '{"name":"青眼"}' cols=name,cardId
+node dist/cli/ygo_extract.js "{青眼の白龍}"
+node dist/cli/ygo_replace.js "{青眼}を召喚" --raw
+node dist/cli/ygo_convert.js input.json:output.csv
 ```
 
 ## Database
 
-- **Total cards**: 13,754
-- **Total FAQs**: 12,578
-- **Format**: TSV (Tab-Separated Values)
-- **Language**: Japanese
-- **Data Files**:
-  - **cards-all.tsv** (8.6MB): Card basic information with 13,754 cards
-  - **detail-all.tsv** (13MB): Detailed card information (stats, effects, etc.)
-  - **faq-all.tsv** (16MB): Official FAQ database with 12,578 entries
-- **Includes**:
-  - Monster, Spell, Trap cards with full text, stats, and supplementary information
-  - Official FAQ with question, answer, and card references
+### Data Files
+
+- **cards-all.tsv** (8.6MB): Card basic information with 13,754 cards
+- **detail-all.tsv** (13MB): Detailed card information (stats, effects, etc.)
+- **faq-all.tsv** (16MB): Official FAQ database with 12,578 entries
+
+### Card Information
+
+- Total cards: 13,754
+- Total FAQs: 12,578
+- Format: TSV (Tab-Separated Values)
+- Language: Japanese
+- Includes: Monster, Spell, Trap cards with full text, stats, and supplementary information
 
 ## Documentation
 
-- [README.md](docs/README.md) - Technical specification
-- [USAGE.md](docs/USAGE.md) - Detailed usage guide
+- [BUILD_AND_RUN.md](docs/BUILD_AND_RUN.md) - Build and development guide
+- [SHELL_COMMANDS.md](docs/SHELL_COMMANDS.md) - Detailed CLI command reference
+- [USAGE.md](docs/USAGE.md) - Usage examples and configuration
+- [CHANGELOG.md](CHANGELOG.md) - Release notes and version history
 
 ## License
 

--- a/docs/BUILD_AND_RUN.md
+++ b/docs/BUILD_AND_RUN.md
@@ -1,33 +1,28 @@
-# ビルドと実行ガイド
+# ビルドと開発ガイド
 
-## 概要
-
-このプロジェクトはTypeScriptで書かれており、実行前に**ビルドが必須**です。
+このプロジェクトはTypeScriptで書かれたNode.js CLIアプリケーションです。使用前にビルドが必須です。
 
 ## ビルドが必要な理由
 
-1. **ES Modules**: 相対インポートに`.js`拡張子が必要
-2. **型チェック**: TypeScriptの型安全性を維持
-3. **パフォーマンス**: コンパイル済みJavaScriptの方が高速
-4. **tsx不要**: ビルド後は`node`コマンドだけで実行可能
+1. **ES Modules**: 相対インポートに`.js`拡張子が必須
+2. **型安全性**: TypeScriptのコンパイルにより型正確性を確保
+3. **パフォーマンス**: コンパイル済みJavaScriptは高速
+4. **シンプリシティ**: ビルド後は`node`コマンドのみで実行可能（`tsx`不要）
 
 ## クイックスタート
 
 ```bash
 # 1. 依存関係をインストール
-npm install
+bun install
 
-# 2. ビルド
-npm run build
+# 2. ビルド（必須！）
+bun run build
 
 # 3. データファイルをダウンロード
 bash scripts/setup/setup-data.sh
 
-# 4. 実行
-npm start
-
-# または CLI コマンドをグローバルインストール
-npm link
+# 4. CLIコマンドを実行
+bun link  # グローバルインストール、または node dist/cli/ygo_search.js を直接実行
 ygo_search '{"name":"青眼"}'
 ```
 
@@ -36,168 +31,74 @@ ygo_search '{"name":"青眼"}'
 ### 基本ビルド
 
 ```bash
-npm run build
+bun run build
 ```
 
-これは以下を実行します:
-1. `dist/`ディレクトリを削除
-2. TypeScript コンパイラ(`tsc`)を実行
-3. `dist/`に`.js`ファイルと`.d.ts`ファイルを生成
+以下を実行します：
+1. `dist/`ディレクトリをクリーン
+2. SWCを使用してTypeScriptをJavaScriptにコンパイル
+3. `dist/`に`.js`ファイルと型定義を生成
 
-### ビルドの確認
+### ビルド出力を確認
 
 ```bash
-# ビルド成果物を確認
-ls -la dist/
-
-# 出力例:
-# dist/
-# ├── ygo-search-card-server.js
-# ├── search-cards.js
-# ├── extract-and-search-cards.js
-# ├── judge-and-replace.js
-# ├── format-converter.js
-# ├── bulk-search-cards.js
-# ├── cli/
-# │   ├── ygo_search.js
-# │   ├── ygo_extract.js
-# │   └── ygo_convert.js
-# ├── lib/
-# │   ├── db.js
-# │   ├── normalize.js
-# │   └── search.js
-# └── utils/
-#     └── pattern-extractor.js
+ls -la dist/cli/
+# 出力: ygo_search.js, ygo_extract.js, ygo_replace.js, ygo_convert.js など
 ```
 
-## 実行方法
+## CLIコマンドの実行
 
-### 1. MCPサーバーとして
-
-```bash
-# ビルド後に実行
-npm start
-
-# または直接
-node dist/ygo-search-card-server.js
-```
-
-### 2. CLIコマンドとして
-
-#### グローバルインストール（推奨）
+### オプション1: グローバルインストール（推奨）
 
 ```bash
-npm link
-```
+# グローバルインストール
+bun link
 
-これで以下のコマンドが使えます:
-- `ygo_search`
-- `ygo_extract`
-- `ygo_convert`
-
-```bash
+# 任意の場所でコマンド使用可能
 ygo_search '{"name":"青眼"}' cols=name,cardId
 ygo_extract "{青眼の白龍}"
-ygo_convert input.json:output.jsonl
+ygo_replace "{青眼}を召喚"
+ygo_seek --max 10
+ygo_faq_search cardId=6808
 ```
 
-#### 直接実行
+### オプション2: 直接実行
 
 ```bash
-node dist/search-cards.js '{"name":"青眼"}' cols=name
-node dist/extract-and-search-cards.js "{青眼}"
-node dist/judge-and-replace.js "{青眼}を召喚"
-node dist/format-converter.js input.json:output.yaml
+# グローバルインストール不要
+node dist/cli/ygo_search.js '{"name":"青眼"}' cols=name,cardId
+node dist/cli/ygo_extract.js "{青眼の白龍}"
+node dist/cli/ygo_replace.js "{青眼}を召喚"
+node dist/cli/ygo_seek.js --max 10
+node dist/cli/ygo_faq_search.js cardId=6808
 ```
 
-### 3. TypeScriptから
+## 開発ワークフロー
 
-```typescript
-import { searchCards } from 'ygo-search-card-mcp'
-
-const results = await searchCards({ name: '青眼' })
-```
-
-**注意**: TypeScriptから使う場合も事前にビルドが必要です。
-
-## 開発モード
-
-### watchモードでビルド
+### ウォッチモードでビルド
 
 ```bash
-# TypeScriptコンパイラをwatchモード起動
-npx tsc --watch
+# 1つのターミナル: TypeScriptファイルの変更を監視してコンパイル
+bun run build --watch
 ```
 
-別のターミナルでMCPサーバーを起動:
+TypeScriptファイルの変更は自動的にJavaScriptにコンパイルされます。
+
+### 開発モード（オプション）
+
+高速な開発のため、TypeScriptを直接実行することも可能です：
 
 ```bash
-npm start
-```
+# tsx をインストール（未インストールの場合）
+bun add -D tsx
 
-ファイルを編集すると自動で再ビルドされ、サーバーを再起動すると変更が反映されます。
-
-### tsxを使った開発（オプション）
-
-開発中のみ`tsx`で直接実行することも可能です:
-
-```bash
-# 開発モードで起動
-npm run dev
-
+# TypeScriptを直接実行
+bun run dev
 # または
-npx tsx src/ygo-search-card-server.ts
+npx tsx src/cli/ygo_search.ts '{"name":"青眼"}'
 ```
 
-**注意**: 本番環境や配布時は必ずビルドしてください。
-
-## tsxが不要になった理由
-
-### 以前（～PR#3）
-
-```bash
-# tsxが必要だった
-npx tsx src/search-cards.ts '{"name":"青眼"}'
-```
-
-### 現在（PR#4以降）
-
-```bash
-# ビルド後はnodeだけでOK
-npm run build
-node dist/search-cards.js '{"name":"青眼"}'
-```
-
-### 変更内容
-
-1. **相対インポートに`.js`拡張子を追加**
-   ```typescript
-   // 修正前
-   import { extract } from './utils/pattern-extractor'
-   
-   // 修正後
-   import { extract } from './utils/pattern-extractor.js'
-   ```
-
-2. **スクリプト内のパスを`.js`に変更**
-   ```typescript
-   // 修正前
-   const script = path.join(__dirname, 'search-cards.ts')
-   spawn('npx', ['tsx', script])
-   
-   // 修正後
-   const script = path.join(__dirname, 'search-cards.js')
-   spawn('node', [script])
-   ```
-
-3. **shebangを`tsx`から`node`に変更**
-   ```typescript
-   // 修正前
-   #!/usr/bin/env tsx
-   
-   // 修正後
-   #!/usr/bin/env node
-   ```
+**注意**: 本番環境と配布時は必ずビルド済みのJavaScriptを使用してください。
 
 ## トラブルシューティング
 
@@ -207,11 +108,11 @@ node dist/search-cards.js '{"name":"青眼"}'
 Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../pattern-extractor'
 ```
 
-**原因**: ビルドしていない
+**原因**: ビルドが実行されていない
 
 **解決策**:
 ```bash
-npm run build
+bun run build
 ```
 
 ### Permission denied
@@ -224,68 +125,102 @@ bash: /usr/local/bin/ygo_search: Permission denied
 
 **解決策**:
 ```bash
-chmod +x dist/**/*.js
-npm link  # 再リンク
+chmod +x dist/cli/*.js
+bun link  # 再リンク
 ```
 
-### tsx: command not found
+### `bun link`後にコマンドが見つからない
 
-```
-zsh:1: command not found: tsx
+```bash
+command not found: ygo_search
 ```
 
-**原因**: スクリプト内で`tsx`を参照している（古いバージョン）
+**原因**: グローバルbinディレクトリがPATHに含まれていない
 
 **解決策**:
 ```bash
-git pull origin dev
-npm run build
-npm link
+# bunのグローバルbinパスを確認
+bun env | grep BUN_INSTALL
+
+# 必要に応じてPATHに追加
+export PATH="$PATH:~/.bun/bin"
+
+# 再リンク
+bun link
 ```
 
-### ビルド後もエラーが出る
+### 完全なリビルド
+
+問題が解決しない場合は完全にリビルドしてください：
 
 ```bash
-# distを完全削除して再ビルド
-npm run prebuild
-npm run build
+# distディレクトリを削除
+rm -rf dist/
 
-# グローバルコマンドを再インストール
-npm unlink -g ygo-search-card-mcp
-npm link
+# リビルド
+bun run build
+
+# CLIコマンドを再リンク
+bun unlink ygo-search-card-mcp 2>/dev/null || true
+bun link
 ```
 
-## CI/CD
+## プロジェクト構造
 
-GitHubActionsでは自動的にビルドとテストが実行されます:
+```
+src/
+├── cli/                    # CLIコマンドスクリプト
+│   ├── ygo_search.ts
+│   ├── ygo_extract.ts
+│   ├── ygo_replace.ts
+│   ├── ygo_convert.ts
+│   ├── ygo_seek.ts
+│   ├── ygo_bulk_search.ts
+│   └── ygo_faq_search.ts
+├── lib/                    # コアライブラリ
+│   ├── card-search-core.ts
+│   ├── normalize.ts
+│   └── db.ts
+├── utils/                  # ユーティリティ
+│   └── pattern-extractor.ts
+└── ygo-search-card-server.ts  # MCPサーバー（廃止予定）
 
-```yaml
-# .github/workflows/test.yml
-- name: Build
-  run: npm run build
+dist/                       # コンパイル済みJavaScript（ビルド後）
+├── cli/
+│   ├── ygo_search.js
+│   ├── ygo_extract.js
+│   ├── ...
+├── lib/
+├── utils/
+└── ...
 
-- name: Run tests
-  run: npm test
+data/                       # カードデータベースファイル（ダウンロード済み）
+├── cards-all.tsv
+├── detail-all.tsv
+└── faq-all.tsv
+```
+
+## テスト
+
+```bash
+# 全テスト実行
+bun test
+
+# 特定ディレクトリのテスト実行
+bun test tests/unit
+
+# カバレッジ付き実行
+bun test --coverage
 ```
 
 ## まとめ
 
-### ✅ やるべきこと
-
-1. `npm install` - 依存関係をインストール
-2. `npm run build` - **必須!** ビルドを実行
-3. `bash scripts/setup/setup-data.sh` - データをダウンロード
-4. `npm link` - CLIコマンドをインストール（オプション）
-
-### ❌ 不要なこと
-
-- ~~`npx tsx`でスクリプトを実行~~ → `node`でOK
-- ~~`tsx`を依存関係に追加~~ → `devDependencies`のみ
-- ~~実行時にTypeScriptファイルを参照~~ → ビルド済み`.js`を使用
-
-### 🚀 結果
-
-- **高速**: コンパイル済みJavaScriptで実行
-- **軽量**: 本番環境に`tsx`不要
-- **安全**: TypeScriptの型チェックを開発時に実施
-- **簡単**: `node`コマンドだけで実行可能
+| タスク | コマンド |
+|--------|---------|
+| 依存関係のインストール | `bun install` |
+| ビルド | `bun run build` |
+| ウォッチモード | `bun run build --watch` |
+| CLIをグローバルインストール | `bun link` |
+| CLIコマンド実行 | `ygo_search '{"name":"青眼"}'` |
+| テスト実行 | `bun test` |
+| 開発モード | `bun run dev` |

--- a/docs/SHELL_COMMANDS.md
+++ b/docs/SHELL_COMMANDS.md
@@ -6,33 +6,40 @@
 cd /path/to/ygo-db-local-mcp
 
 # 1. Install dependencies
-npm install
+bun install
 
 # 2. Build project (required!)
-npm run build
+bun run build
 
-# 3. Install global commands (optional)
-npm link
+# 3. Download data files
+bash scripts/setup/setup-data.sh
+
+# 4. Install global commands (optional)
+bun link
 ```
 
 This creates global commands:
 - `ygo_search` - Search cards
 - `ygo_bulk_search` - Bulk search
 - `ygo_extract` - Extract and search card patterns from text
-- `ygo_convert` - Convert between JSON/JSONL/JSONC/YAML formats
+- `ygo_replace` - Replace card patterns with card IDs or names
+- `ygo_seek` - Get random or range-specific cards
+- `ygo_faq_search` - Search FAQ database
+- `ygo_convert` - Convert between JSON/JSONL/CSV/TSV formats
 
-**Note**: After build, scripts work without tsx!
+**Note**: After build, scripts work with `node` (no tsx required)!
 
 ## PATH Setup
 
-If commands are not found after `npm link`, ensure your npm global bin directory is in PATH:
+If commands are not found after `bun link`, ensure your bun global bin directory is in PATH:
 
 ```bash
-# Check npm global bin path
-npm config get prefix
+# Check bun global bin path
+bun env | grep BUN_INSTALL
+# Usually: ~/.bun
 
 # Add to ~/.bashrc or ~/.zshrc
-export PATH="$(npm config get prefix)/bin:$PATH"
+export PATH="$PATH:~/.bun/bin"
 ```
 
 Then reload:
@@ -81,9 +88,62 @@ ygo_extract "{青眼の白龍}とブラック・マジシャンを召喚"
 
 # With multiple pattern types
 ygo_extract "{ブルーアイズ*}と《青眼の白龍》と{{真紅眼の黒竜|6349}}"
+```
 
-# Output to file
-ygo_extract "{青眼}で攻撃" outputPath=extracted.jsonl
+### ygo_replace - Replace card patterns with card IDs or names
+
+```bash
+# Replace with card ID: {{name|id}}
+ygo_replace "{青眼の白龍}を召喚" --raw
+
+# Replace with card name: 《name》
+ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
+
+# Replace multiple patterns
+ygo_replace "1ターンに{青眼の白龍}と{ブラック・マジシャン}を召喚"
+```
+
+### ygo_seek - Get random or range-specific cards
+
+```bash
+# Random cards
+ygo_seek --max 5
+
+# Range selection
+ygo_seek --range 4000-5000 --max 20
+
+# All cards in range
+ygo_seek --range 4000-4100 --all
+
+# Different output formats
+ygo_seek --max 10 --format csv
+ygo_seek --max 10 --format jsonl --col cardId,name,atk,def
+ygo_seek --max 10 --col-all  # All columns
+```
+
+### ygo_faq_search - Search FAQ database
+
+```bash
+# Search by FAQ ID
+ygo_faq_search faqId=100
+
+# Search by card ID
+ygo_faq_search cardId=6808 limit=5
+
+# Search by card name
+ygo_faq_search cardName="青眼*" limit=10
+
+# Search by card specifications
+ygo_faq_search cardFilter.race=dragon cardFilter.levelValue=8
+
+# Search by question/answer text
+ygo_faq_search question="*シンクロ召喚*"
+ygo_faq_search answer="*無効*" limit=20
+
+# Output options
+ygo_faq_search cardId=6808 --fcol faqId,question
+ygo_faq_search cardId=6808 --col name,atk,def
+ygo_faq_search cardName="青眼*" --format csv
 ```
 
 ### ygo_convert - Convert file formats
@@ -92,13 +152,16 @@ ygo_extract "{青眼}で攻撃" outputPath=extracted.jsonl
 # JSON to JSONL
 ygo_convert input.json:output.jsonl
 
-# YAML to JSON
-ygo_convert data.yaml:output.json
+# JSON to CSV
+ygo_convert input.json:output.csv
+
+# JSONL to TSV
+ygo_convert input.jsonl:output.tsv
 
 # Multiple conversions
-ygo_convert a.json:a.yaml b.jsonl:b.json
+ygo_convert a.json:a.csv b.jsonl:b.tsv
 
-# Supported formats: .json, .jsonl, .jsonc, .yaml, .yml
+# Supported formats: .json, .jsonl, .csv, .tsv
 ```
 
 ## Environment Variables
@@ -132,5 +195,5 @@ ygo_convert --help
 ## Uninstall
 
 ```bash
-npm unlink -g ygo-search-card-mcp
+bun unlink ygo-search-card-mcp
 ```

--- a/docs/SHELL_COMMANDS.md
+++ b/docs/SHELL_COMMANDS.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-cd /path/to/ygo-db-local-mcp
+cd /path/to/YuGiOh-Search-CLI
 
 # 1. Install dependencies
 bun install

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -35,7 +35,7 @@ Edit `%APPDATA%\Claude\claude_desktop_config.json`:
   "mcpServers": {
     "ygo-search-card": {
       "command": "node",
-      "args": ["C:\\absolute\\path\\to\\ygo-db-local-mcp\\src\\ygo-search-card-server.js"]
+      "args": ["C:\\absolute\\path\\to\\ygo-db-local-mcp\\dist\\ygo-search-card-server.js"]
     }
   }
 }
@@ -49,7 +49,7 @@ Open Cline MCP settings and add:
 {
   "ygo-search-card": {
     "command": "node",
-    "args": ["/absolute/path/to/ygo-db-local-mcp/src/ygo-search-card-server.js"]
+    "args": ["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]
   }
 }
 ```
@@ -58,10 +58,12 @@ Open Cline MCP settings and add:
 
 Configure with:
 - **Command**: `node`
-- **Args**: `["/absolute/path/to/ygo-db-local-mcp/src/ygo-search-card-server.js"]`
+- **Args**: `["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]`
 - **Transport**: stdio (JSON-RPC 2.0)
 
-**Important:** Use absolute paths. Replace `/absolute/path/to/` with your actual installation directory.
+**Important:**
+- Use absolute paths. Replace `/absolute/path/to/` with your actual installation directory.
+- Use the `dist/` directory path, not `src/`. The server must be built before use.
 
 After adding the configuration, restart your MCP client.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,506 +1,260 @@
-# Yu-Gi-Oh Card Search MCP Server
+# CLI Usage Guide
 
 ## Installation
 
-Already installed. Dependencies:
-- `@modelcontextprotocol/sdk`
-- `tsx` (for running TypeScript)
-- `zod` (for parameter validation)
-
-## MCP Client Configuration
-
-### Claude Desktop
-
-**macOS/Linux:**
-
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `~/.config/Claude/claude_desktop_config.json` (Linux):
-
-```json
-{
-  "mcpServers": {
-    "ygo-search-card": {
-      "command": "node",
-      "args": ["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]
-    }
-  }
-}
-```
-
-**Windows:**
-
-Edit `%APPDATA%\Claude\claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "ygo-search-card": {
-      "command": "node",
-      "args": ["C:\\absolute\\path\\to\\ygo-db-local-mcp\\dist\\ygo-search-card-server.js"]
-    }
-  }
-}
-```
-
-### Cline (VS Code Extension)
-
-Open Cline MCP settings and add:
-
-```json
-{
-  "ygo-search-card": {
-    "command": "node",
-    "args": ["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]
-  }
-}
-```
-
-### Other MCP Clients
-
-Configure with:
-- **Command**: `node`
-- **Args**: `["/absolute/path/to/ygo-db-local-mcp/dist/ygo-search-card-server.js"]`
-- **Transport**: stdio (JSON-RPC 2.0)
-
-**Important:**
-- Use absolute paths. Replace `/absolute/path/to/` with your actual installation directory.
-- Use the `dist/` directory path, not `src/`. The server must be built before use.
-
-After adding the configuration, restart your MCP client.
-
-## Usage
-
-### As MCP Server
-
-Start the server manually (for testing):
 ```bash
-node dist/ygo-search-card-server.js
-# or
-npm start
+# Clone and setup
+git clone https://github.com/TomoTom0/ygo-db-local-mcp.git
+cd ygo-db-local-mcp
+
+# Install dependencies
+bun install
+
+# Build project (required!)
+bun run build
+
+# Download data files
+bash scripts/setup/setup-data.sh
+
+# Install CLI commands globally (optional)
+bun link
 ```
 
-The server communicates via stdio using JSON-RPC 2.0 protocol.
+## CLI Commands
 
-### Direct CLI Usage
+All commands can be used globally after `bun link`, or directly with `node dist/cli/`.
+
+### ygo_search - Search Cards
 
 ```bash
-# After npm link, use global commands:
+# Basic search by name
+ygo_search '{"name":"青眼の白龍"}' cols=name,cardId
 
-# Exact match with wildcard
-ygo_search '{"name":"ブルーアイズ*"}' cols=name,cardId
-
-# Find cards ending with "ドラゴン"
+# Wildcard search (matches any characters)
+ygo_search '{"name":"ブルーアイズ*"}' cols=name,atk
 ygo_search '{"name":"*ドラゴン"}' cols=name,atk
 
-# Partial match (substring search, no wildcard)
+# Partial match (substring, no wildcard)
 ygo_search '{"name":"青眼"}' cols=name,cardId mode=partial
 
-# Disable wildcard to search for literal "*"
-ygo_search '{"name":"*"}' cols=name flagAllowWild=false
+# Search multiple conditions
+ygo_search '{"cardType":"モンスター","race":"ドラゴン族"}' cols=name,atk,def
+
+# Search by card ID
+ygo_search '{"cardId":"6808"}' cols=name,text
+
+# Search text (case-insensitive)
+ygo_search '{"text":"*破壊*"}' cols=name,text
+
+# Negative search (exclude)
+ygo_search '{"text":"*破壊*","name":"-\"フィールド\""}' cols=name,text
+
+# With output columns
+ygo_search '{"name":"青眼"}' cols=name,cardId,atk,def,text
+
+# Available columns: name, cardId, cardType, race, level, atk, def, text, detail, effect, etc.
 ```
 
-## MCP Tools
+### ygo_bulk_search - Bulk Search (Multiple Cards)
 
-### search_cards
-
-Single card search tool.
-
-**Parameters:**
-- `filter` (object, required): Field-value pairs for filtering
-- `cols` (array of strings, optional): Columns to return
-- `mode` (string, optional): "exact" (default) or "partial"
-- `includeRuby` (boolean, optional, default: true): When true and filtering by name, also searches the ruby (reading) field
-- `flagAutoPend` (boolean, optional, default: true): When true and cols includes 'text', automatically includes pendulumText/pendulumSupplementInfo for pendulum monsters
-- `flagAutoSupply` (boolean, optional, default: true): When true and cols includes 'text', automatically includes supplementInfo (always, even if empty)
-- `flagAutoRuby` (boolean, optional, default: true): When true and cols includes 'name', automatically includes ruby (reading)
-- `flagAutoModify` (boolean, optional, default: true): When filtering by name, normalizes input to ignore whitespace, symbols (including ・★☆※‼！？。、:：;；brackets, quotes, and other punctuation), case, half/full width, hiragana/katakana differences, and kanji variants (竜→龍). Uses pre-computed nameModified column for efficient matching.
-- `flagAllowWild` (boolean, optional, default: true): When true, treats `*` (asterisk) as a wildcard that matches any characters in name and text fields (text, pendulumText, supplementInfo, pendulumSupplementInfo). Works with flagAutoModify. Cannot be used with mode=partial. Also supports negative search: `(space|　)-"phrase"` or `-'phrase'` or `-\`phrase\`` to exclude cards containing the phrase.
-- `flagNearly` (boolean, optional, default: false): (TODO - not yet implemented) When true, uses fuzzy matching for name search to handle typos and minor variations
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "search_cards",
-    "arguments": {
-      "filter": {"name": "ブルーアイズ*"},
-      "cols": ["name", "atk"],
-      "mode": "exact"
-    }
-  }
-}
-```
-
-**Wildcard search examples:**
-```json
-// Find all cards starting with "ブルーアイズ"
-{"filter": {"name": "ブルーアイズ*"}, "cols": ["name"]}
-
-// Find all cards ending with "ドラゴン"
-{"filter": {"name": "*ドラゴン"}, "cols": ["name"]}
-
-// Find all cards containing "Evil" and "Twin" in that order
-{"filter": {"name": "Evil*Twin*"}, "cols": ["name"]}
-
-// Text field wildcard: find cards with "destroy" and "monster"
-{"filter": {"text": "*destroy*monster*"}, "cols": ["name", "text"]}
-
-// Disable wildcard to search for literal "*"
-{"filter": {"name": "*ドラゴン"}, "cols": ["name"], "flagAllowWild": false}
-```
-
-**Negative search examples:**
-```json
-// Find cards with "destroy" but not "negate"
-{"filter": {"text": "destroy -\"negate\""}, "cols": ["name", "text"]}
-
-// Find cards with "special summon" but not "hand" or "deck"
-{"filter": {"text": "special summon -\"hand\" -\"deck\""}, "cols": ["name", "text"]}
-
-// Combine wildcard and negative: cards with "dragon" but not "effect"
-{"filter": {"text": "*dragon* -\"effect\""}, "cols": ["name", "text"]}
-
-// Only negative: cards without "once per turn"
-{"filter": {"text": "-\"once per turn\""}, "cols": ["name", "text"]}
-
-// Use single quotes or backticks
-{"filter": {"text": "destroy -'target'"}, "cols": ["name"]}
-{"filter": {"text": "summon -`negate`"}, "cols": ["name"]}
-```
-
-**Note on negative search:**
-- Syntax: `(space|　)-"phrase"` or `-'phrase'` or `-\`phrase\``
-- Can appear anywhere in the search pattern
-- Works with text, pendulumText, supplementInfo, pendulumSupplementInfo fields
-- Also works with name field
-- Multiple negative patterns are supported
-- Can be combined with wildcards
-
-### bulk_search_cards
-
-**New!** Bulk search multiple cards at once. Much more efficient than calling search_cards multiple times.
-
-**Performance**: ~73% faster than individual calls for 10 queries.
-
-**Parameters:**
-- `queries` (array, required): Array of query objects (1-50 queries)
-  - Each query has the same structure as `search_cards` parameters
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "bulk_search_cards",
-    "arguments": {
-      "queries": [
-        {"filter": {"name": "青眼の白龍"}, "cols": ["name", "atk"]},
-        {"filter": {"name": "ブラック・マジシャン"}, "cols": ["name", "atk"]},
-        {"filter": {"cardId": "4007"}, "cols": ["name", "text"]}
-      ]
-    }
-  }
-}
-```
-
-**Response format:**
-```json
-[
-  [{"name": "青眼の白龍", "atk": "3000"}],
-  [{"name": "ブラック・マジシャン", "atk": "2500"}],
-  []
-]
-```
-
-Each element is an array of results (same as `search_cards`). Empty arrays indicate no matches or errors.
-
-### extract_and_search_cards
-
-**New!** Extract card name patterns from text and search for them automatically.
-
-**Card name patterns:**
-- `{card-name}` - Flexible search with wildcards and normalization (e.g., `{ブルーアイズ*}`)
-- `《card-name》` - Exact search with normalization but no wildcards (e.g., `《青眼の白龍》`)
-- `{{card-name|cardId}}` - Search by card ID (most precise) (e.g., `{{青眼の白龍|4007}}`)
-
-**Parameters:**
-- `text` (string, required): Text containing card name patterns
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "extract_and_search_cards",
-    "arguments": {
-      "text": "効果：{{青眼の白龍|4007}}を墓地へ送り、{Evil*Twin*}を特殊召喚できる。"
-    }
-  }
-}
-```
-
-**Response format:**
-```json
-{
-  "cards": [
-    {
-      "pattern": "{{青眼の白龍|4007}}",
-      "type": "cardId",
-      "query": "4007",
-      "results": [/* full card data */]
-    },
-    {
-      "pattern": "{Evil*Twin*}",
-      "type": "flexible",
-      "query": "Evil*Twin*",
-      "results": [/* 8 cards matching pattern */]
-    }
-  ]
-}
-```
-
-**Direct CLI usage:**
 ```bash
-ygo_extract "Use {ブルーアイズ*} and 《青眼の白龍》"
+# Search multiple cards at once
+ygo_bulk_search '[{"filter":{"name":"青眼"}},{"filter":{"name":"ブラック・マジシャン"}}]'
+
+# With columns
+ygo_bulk_search '[{"filter":{"race":"ドラゴン族"}},{"filter":{"race":"魔法使い族"}}]' cols=name,race,atk
+
+# Up to 50 queries
+ygo_bulk_search '[{"filter":{"name":"青眼"}},{"filter":{"name":"ホワイト・ホルス"}}, ...]'
 ```
 
-**Note:**
-- All fields are included in results (same as specifying all columns in `search_cards`)
-- Patterns are extracted in order: `{{...}}` first, then `《...》`, then `{...}`
-- If no patterns are found, returns empty `cards` array
+### ygo_extract - Extract Card Patterns from Text
 
-### judge_and_replace_cards
+Extract card name patterns for later processing.
 
-**New!** Extract card patterns, search, and intelligently replace them based on match results.
-
-**Replacement Logic:**
-- **1 match** → `{{card-name|cardId}}` (automatically resolved)
-- **Multiple matches** → ``{{`original-query`_`name|id`_`name|id`_...}}`` (requires manual selection)
-- **No matches** → ``{{NOTFOUND_`original-query`}}`` (marked as not found)
-- **Already processed** → `{{name|id}}` patterns are preserved
-
-**Parameters:**
-- `text` (string, required): Text containing card name patterns
-
-**Example MCP request:**
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "judge_and_replace_cards",
-    "arguments": {
-      "text": "Use {ブルーアイズ*} and 《青眼の白龍》 cards"
-    }
-  }
-}
-```
-
-**Response format:**
-```json
-{
-  "processedText": "Use {{`ブルーアイズ*`_`青眼の白龍|4007`_`青眼の究極竜|2129`_...}} and {{青眼の白龍|4007}} cards",
-  "hasUnprocessed": true,
-  "warnings": [
-    "⚠️ Text contains unprocessed patterns that require manual review",
-    "Found 1 pattern(s) with multiple matches - please select correct one"
-  ],
-  "processedPatterns": [
-    {
-      "original": "{ブルーアイズ*}",
-      "replaced": "{{`ブルーアイズ*`_`青眼の白龍|4007`_`青眼の究極竜|2129`_...}}",
-      "status": "multiple"
-    },
-    {
-      "original": "《青眼の白龍》",
-      "replaced": "{{青眼の白龍|4007}}",
-      "status": "resolved"
-    }
-  ]
-}
-```
-
-**Direct CLI usage:**
 ```bash
-ygo_replace "Use {ブルーアイズ*} and 《青眼の白龍》"
+# Extract patterns from text
+ygo_extract "{青眼の白龍}とブラック・マジシャンを召喚"
+
+# Supported patterns:
+# - {flexible}       - Flexible search with wildcards and normalization
+# - 《exact》        - Exact search with normalization
+# - {{name|id}}      - Search by card ID
+
+# Multiple pattern types
+ygo_extract "{ブルーアイズ*}と《青眼の白龍》と{{真紅眼の黒竜|6349}}"
 ```
 
-**Workflow:**
-1. Extract patterns from text
-2. Search for each pattern
-3. Replace based on match count
-4. User manually edits ambiguous/not-found patterns
-5. Re-run `judge_and_replace_cards` on edited text
-6. Repeat until `hasUnprocessed` is false
+### ygo_replace - Replace Card Patterns with IDs or Names
 
-**Note:**
-- Backticks (`` ` ``) are used to distinguish multi-match candidates from card names containing underscores
-- Already processed `{{name|id}}` patterns are skipped and preserved
-- Warnings are provided when manual intervention is needed
-
-## Additional Notes
-
-**Note:** 
-- When `includeRuby` is true, searching for "ブルーアイズ" will match both cards with "ブルーアイズ" in the `name` field and in the `ruby` field (like "青眼の白龍" with ruby "ブルーアイズ・ホワイト・ドラゴン")
-- When `flagAutoRuby` is true (default), requesting `cols=["name"]` will automatically include `ruby` in results
-- When `flagAutoPend` is true (default), requesting `cols=["text"]` for pendulum monsters will automatically include `pendulumText` and `pendulumSupplementInfo`
-- When `flagAutoModify` is true (default), kanji variants are normalized (e.g., "天盃竜" matches "天盃龍"), and name searches ignore whitespace, symbols, case differences, full/half-width, and hiragana/katakana differences. For example, "あしすと　やみー" will match "アシスト★ヤミー！"
-- When `flagAllowWild` is true (default), `*` acts as a wildcard in name searches. For example, "ブルーアイズ*" matches all cards starting with "ブルーアイズ". This works with normalized searches (flagAutoModify), so "ぶるーあいず*" also matches.
-- By default (flagAutoSupply=true), requesting `text` will automatically include `supplementInfo`, and requesting `pendulumText` will include `pendulumSupplementInfo`
-- flagAutoPend only includes supplement fields if they are not empty, while flagAutoSupply always includes them when text/pendulumText is requested
-- `mode=partial` and `flagAllowWild=true` cannot be used together
-
-### ygo_replace - Replace Card Patterns
-
-Extract card name patterns and replace with verified card IDs or exact names.
-
-**Basic Usage:**
 ```bash
-ygo_replace "{青眼の白龍}を召喚して攻撃"
-# Output: {"processedText":"{{青眼の白龍|4007}}を召喚して攻撃",...}
-```
-
-**Options:**
-- `--raw`: Output only the processed text (no JSON)
-- `--mount-par`: Use 《name》 format instead of {{name|id}}
-
-**Examples:**
-```bash
-# Normal mode with JSON output
-ygo_replace "{青眼の白龍}を召喚"
-
-# Raw text output
+# Replace patterns with card IDs: {{name|cardId}}
 ygo_replace "{青眼の白龍}を召喚" --raw
-# Output: {{青眼の白龍|4007}}を召喚
 
-# Mount-par mode (exact name format)
+# Replace patterns with card names: 《cardName》
 ygo_replace "{青眼の白龍}を召喚" --mount-par --raw
-# Output: 《青眼の白龍》を召喚
 
-# Multiple cards
-ygo_replace "デッキ: {青眼の白龍} x3, {真紅眼の黒竜} x2" --raw
-# Output: デッキ: {{青眼の白龍|4007}} x3, {{真紅眼の黒竜|4088}} x2
+# Replace multiple patterns in one text
+ygo_replace "1ターンに{青眼の白龍}と{ブラック・マジシャン}を召喚"
 
-# With wildcards
-ygo_replace "{ブルーアイズ*}を使う" --mount-par --raw
+# Options:
+# --raw          - Output raw replacement without JSON wrapping
+# --mount-par    - Use 《name》 format instead of {{name|cardId}}
 ```
 
-### ygo_seek - Random Card Retrieval
+### ygo_seek - Get Random or Range-Specific Cards
 
-Get random or range-specific card information from the database.
-
-**Basic Usage:**
 ```bash
-# Get 10 random cards (default)
-ygo_seek
-
-# Get 5 random cards
+# Get random cards
 ygo_seek --max 5
-```
 
-**Options:**
-- `--max N`: Maximum number of cards (default: 10)
-- `--random`: Enable random selection (default: true)
-- `--no-random`: Disable random selection (sequential)
-- `--range start-end`: Filter by cardId range
-- `--all`: Get all cards in range (overrides --max, requires --range)
-- `--col a,b,c`: Columns to retrieve (default: cardId,name)
-- `--format FORMAT`: Output format - json|csv|tsv|jsonl (default: json)
+# Get random cards with specific columns
+ygo_seek --max 10 --col cardId,name,atk,def
 
-**Examples:**
-```bash
-# Random 5 cards with specific columns
-ygo_seek --max=5 --col=cardId,name,atk,def
-
-# Cards in range 4000-5000 (random 20)
-ygo_seek --range=4000-5000 --max=20
+# Range selection (CardId range)
+ygo_seek --range 4000-5000 --max 20
 
 # All cards in range
-ygo_seek --range=4000-4100 --all
+ygo_seek --range 4000-4100 --all
 
-# CSV format output
-ygo_seek --max=10 --format=csv --col=cardId,name,atk,def
+# Different output formats
+ygo_seek --max 10 --format json    # Default
+ygo_seek --max 10 --format jsonl   # One per line
+ygo_seek --max 10 --format csv
+ygo_seek --max 10 --format tsv
 
-# TSV format for range
-ygo_seek --range=4000-4050 --all --format=tsv
+# Get all columns
+ygo_seek --max 10 --col-all
 
-# JSONL format (one JSON per line)
-ygo_seek --max=5 --format=jsonl
-
-# Non-random (sequential) selection
-ygo_seek --range=4000-4100 --no-random --max=10
+# Options:
+# --max N           - Get N random cards
+# --range START-END - CardId range (inclusive)
+# --all             - Get all cards in range
+# --format FORMAT   - Output format (json, jsonl, csv, tsv)
+# --col COLS        - Comma-separated columns to include
+# --col-all         - Include all available columns
 ```
 
-**Output Examples:**
+### ygo_faq_search - Search Official FAQ Database
 
-JSON (default):
-```json
-[
-  {
-    "cardId": "4007",
-    "name": "青眼の白龍"
-  },
-  {
-    "cardId": "4088",
-    "name": "真紅眼の黒竜"
-  }
-]
-```
-
-CSV:
-```csv
-"cardId","name","atk"
-"4007","青眼の白龍","3000"
-"4088","真紅眼の黒竜","2400"
-```
-
-TSV:
-```
-cardId	name	atk
-4007	青眼の白龍	3000
-4088	真紅眼の黒竜	2400
-```
-
-JSONL:
-```
-{"cardId":"4007","name":"青眼の白龍"}
-{"cardId":"4088","name":"真紅眼の黒竜"}
-```
-
-
-**Available Columns (26 total):**
-
-From cards-all.tsv (21 columns):
-```
-cardType, name, nameModified, ruby, cardId, ciid, imgs, text, 
-attribute, levelType, levelValue, race, monsterTypes, atk, def, 
-linkMarkers, pendulumScale, pendulumText, isExtraDeck, 
-spellEffectType, trapEffectType
-```
-
-From detail-all.tsv (5 additional columns):
-```
-cardName, supplementInfo, supplementDate, 
-pendulumSupplementInfo, pendulumSupplementDate
-```
-
-Note: cardId appears in both files but is not duplicated in output.
-
-**Getting all columns:**
 ```bash
-# All columns in JSON format
-ygo_seek --max 5 --col-all
+# Search by FAQ ID
+ygo_faq_search faqId=100
 
-# All columns in CSV format (good for spreadsheet import)
-ygo_seek --range 4000-4100 --all --col-all --format csv > cards.csv
+# Search by card ID
+ygo_faq_search cardId=6808 limit=5
 
-# All columns in TSV format
-ygo_seek --max 100 --col-all --format tsv > cards.tsv
+# Search by card name (with wildcard)
+ygo_faq_search cardName="青眼*" limit=10
+
+# Search by card specifications
+ygo_faq_search cardFilter.race=dragon cardFilter.levelValue=8
+
+# Search by question text (with wildcard)
+ygo_faq_search question="*シンクロ召喚*"
+
+# Search by answer text
+ygo_faq_search answer="*無効*" limit=20
+
+# Output options
+ygo_faq_search cardId=6808 --fcol faqId,question  # FAQ columns only
+ygo_faq_search cardId=6808 --col name,atk,def    # Card columns only
+ygo_faq_search cardName="青眼*" --format csv
+
+# Key=value style (CLI-friendly)
+ygo_faq_search cardId=6808 limit=5
+ygo_faq_search question="*効果*" answer="*無効*" limit=10
+
+# Options:
+# limit N          - Limit number of results (default: all)
+# --fcol COLS      - FAQ columns to output
+# --col COLS       - Card columns to output
+# --format FORMAT  - Output format (json, csv, tsv)
+# --random         - Random selection from results
 ```
+
+### ygo_convert - Convert File Formats
+
+```bash
+# Convert JSON to JSONL
+ygo_convert input.json:output.jsonl
+
+# Convert JSON to CSV
+ygo_convert input.json:output.csv
+
+# Convert JSONL to TSV
+ygo_convert input.jsonl:output.tsv
+
+# Multiple conversions
+ygo_convert a.json:a.csv b.jsonl:b.tsv c.csv:c.json
+
+# Supported formats: .json, .jsonl, .csv, .tsv
+```
+
+## Advanced Usage
+
+### Search Pattern Normalization
+
+All searches automatically normalize:
+- Whitespace and symbols (・★☆ etc.)
+- Full-width/half-width characters
+- Uppercase/lowercase
+- Hiragana/katakana
+- Kanji variants (竜→龍)
+
+### Wildcard Syntax
+
+- `*` matches any characters: `{ブルーアイズ*}`, `{*ドラゴン}`
+- `-"phrase"` excludes cards containing phrase: `{text: "summon -\"negate\"" }`
+
+### Output Examples
+
+```bash
+# Pretty JSON output
+ygo_search '{"name":"青眼"}' | jq .
+
+# Filter results
+ygo_search '{"cardType":"モンスター"}' cols=name,cardId | jq '.[] | select(.atk > 2500)'
+
+# Save to file
+ygo_search '{"name":"青眼"}' > results.json
+
+# Pipe to other commands
+ygo_search '{"race":"ドラゴン族"}' cols=name,cardId | wc -l
+```
+
+## Environment Variables
+
+```bash
+# Set default output format
+export YGO_FORMAT=jsonl
+
+# Now all commands default to JSONL format
+ygo_search '{"name":"青眼"}'
+```
+
+## Help
+
+```bash
+ygo_search --help
+ygo_bulk_search --help
+ygo_extract --help
+ygo_replace --help
+ygo_seek --help
+ygo_faq_search --help
+ygo_convert --help
+```
+
+## MCP Server (Deprecated)
+
+For historical reference, the MCP server can still be used:
+
+```bash
+# Start MCP server (CLI recommended instead)
+node dist/ygo-search-card-server.js
+
+# Or via npm
+bun start
+```
+
+However, the CLI commands are the recommended way to use this project.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,8 +4,8 @@
 
 ```bash
 # Clone and setup
-git clone https://github.com/TomoTom0/ygo-db-local-mcp.git
-cd ygo-db-local-mcp
+git clone https://github.com/TomoTom0/YuGiOh-Search-CLI.git
+cd YuGiOh-Search-CLI
 
 # Install dependencies
 bun install

--- a/scripts/setup/setup-data.sh
+++ b/scripts/setup/setup-data.sh
@@ -12,7 +12,52 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_DIR="$SCRIPT_DIR/../../data"
 RELEASE_URL="https://github.com/TomoTom0/ygo-db-local-mcp/releases/download"
-VERSION="${1:-v1.0.0}"
+VERSION="${1:-v1.3.0}"
+
+# Data files to download
+declare -a DATA_FILES=("cards-all.tsv" "detail-all.tsv" "faq-all.tsv")
+
+# Function to download a file
+download_file() {
+  local filename="$1"
+  local filepath="$DATA_DIR/$filename"
+
+  echo "Downloading $filename..."
+  HTTP_CODE=$(curl -L -w "%{http_code}" -o "$filepath" -sS \
+    "$RELEASE_URL/$VERSION/$filename" 2>&1 | tail -n 1)
+
+  if [ "$HTTP_CODE" != "200" ]; then
+    echo "Error: Failed to download $filename (HTTP $HTTP_CODE)"
+    echo "URL: $RELEASE_URL/$VERSION/$filename"
+    echo ""
+    echo "Possible reasons:"
+    echo "  - Version '$VERSION' does not exist"
+    echo "  - Release does not have $filename attached"
+    echo "  - Network issue"
+    echo ""
+    echo "Available versions: https://github.com/TomoTom0/ygo-db-local-mcp/releases"
+    rm -f "$filepath"
+    exit 1
+  fi
+}
+
+# Function to verify file size
+verify_file_size() {
+  local filename="$1"
+  local filepath="$DATA_DIR/$filename"
+  local MIN_SIZE=1000000
+
+  local filesize=$(stat -f%z "$filepath" 2>/dev/null || stat -c%s "$filepath" 2>/dev/null)
+
+  if [ "$filesize" -lt $MIN_SIZE ]; then
+    echo "Error: Downloaded file is too small (possibly error page)"
+    echo "$filename: $filesize bytes (expected at least $MIN_SIZE bytes)"
+    rm -f "$filepath"
+    exit 1
+  fi
+
+  echo "$filesize"
+}
 
 echo "=== YGO MCP Server - Data Setup ==="
 echo ""
@@ -23,55 +68,29 @@ echo ""
 # Create data directory if it doesn't exist
 mkdir -p "$DATA_DIR"
 
-# Download cards-all.tsv
-echo "Downloading cards-all.tsv..."
-HTTP_CODE=$(curl -L -w "%{http_code}" -o "$DATA_DIR/cards-all.tsv" -sS \
-  "$RELEASE_URL/$VERSION/cards-all.tsv" 2>&1 | tail -n 1)
-
-if [ "$HTTP_CODE" != "200" ]; then
-  echo "Error: Failed to download cards-all.tsv (HTTP $HTTP_CODE)"
-  echo "URL: $RELEASE_URL/$VERSION/cards-all.tsv"
-  echo ""
-  echo "Possible reasons:"
-  echo "  - Version '$VERSION' does not exist"
-  echo "  - Release does not have cards-all.tsv attached"
-  echo "  - Network issue"
-  echo ""
-  echo "Available versions: https://github.com/TomoTom0/ygo-db-local-mcp/releases"
-  rm -f "$DATA_DIR/cards-all.tsv"
-  exit 1
-fi
-
-# Download detail-all.tsv
-echo "Downloading detail-all.tsv..."
-HTTP_CODE=$(curl -L -w "%{http_code}" -o "$DATA_DIR/detail-all.tsv" -sS \
-  "$RELEASE_URL/$VERSION/detail-all.tsv" 2>&1 | tail -n 1)
-
-if [ "$HTTP_CODE" != "200" ]; then
-  echo "Error: Failed to download detail-all.tsv (HTTP $HTTP_CODE)"
-  echo "URL: $RELEASE_URL/$VERSION/detail-all.tsv"
-  rm -f "$DATA_DIR/detail-all.tsv"
-  exit 1
-fi
+# Download all data files
+for filename in "${DATA_FILES[@]}"; do
+  download_file "$filename"
+done
 
 # Verify file sizes
-CARDS_SIZE=$(stat -f%z "$DATA_DIR/cards-all.tsv" 2>/dev/null || stat -c%s "$DATA_DIR/cards-all.tsv" 2>/dev/null)
-DETAIL_SIZE=$(stat -f%z "$DATA_DIR/detail-all.tsv" 2>/dev/null || stat -c%s "$DATA_DIR/detail-all.tsv" 2>/dev/null)
-
-if [ "$CARDS_SIZE" -lt 1000000 ] || [ "$DETAIL_SIZE" -lt 1000000 ]; then
-  echo "Error: Downloaded files are too small (possibly error pages)"
-  echo "cards-all.tsv: $CARDS_SIZE bytes"
-  echo "detail-all.tsv: $DETAIL_SIZE bytes"
-  exit 1
-fi
+echo ""
+echo "Verifying file sizes..."
+declare -A FILE_SIZES
+for filename in "${DATA_FILES[@]}"; do
+  FILE_SIZES[$filename]=$(verify_file_size "$filename")
+done
 
 echo ""
-echo "✓ Data files downloaded successfully!"
+echo "Data files downloaded successfully!"
 echo ""
 echo "Files location:"
-echo "  - $DATA_DIR/cards-all.tsv ($(numfmt --to=iec-i --suffix=B $CARDS_SIZE 2>/dev/null || echo "$CARDS_SIZE bytes"))"
-echo "  - $DATA_DIR/detail-all.tsv ($(numfmt --to=iec-i --suffix=B $DETAIL_SIZE 2>/dev/null || echo "$DETAIL_SIZE bytes"))"
+for filename in "${DATA_FILES[@]}"; do
+  filesize=${FILE_SIZES[$filename]}
+  formatted_size=$(numfmt --to=iec-i --suffix=B $filesize 2>/dev/null || echo "$filesize bytes")
+  echo "  - $DATA_DIR/$filename ($formatted_size)"
+done
 echo ""
 echo "You can now use the MCP server:"
-echo "  node src/ygo-search-card-server.js"
+echo "  node dist/ygo-search-card-server.js"
 echo ""


### PR DESCRIPTION
## 概要

v1.3.0リリースに伴うドキュメント更新とプロジェクト統一を行いました。

## 主な変更

### v1.3.0リリース準備
- ✅ CHANGELOG.md を作成
- ✅ setup-data.sh を faq-all.tsv 対応へ更新
- ✅ README.md、docs/USAGE.md、docs/BUILD_AND_RUN.md を更新

### ドキュメントのCLI中心への再構成
- ✅ README.md を CLI 中心に完全に再構成
- ✅ docs/BUILD_AND_RUN.md を簡潔に再構成（MCPは最小化）
- ✅ docs/SHELL_COMMANDS.md を新しいCLIコマンドで更新
- ✅ docs/USAGE.md を「CLI Usage Guide」に変更

### パッケージマネージャーのnpm→bunへ統一
- ✅ README.md、docs全体を bun コマンドで統一

### リポジトリ名・説明の更新
- ✅ リポジトリ名: ygo-db-local-mcp → YuGiOh-Search-CLI
- ✅ リポジトリ説明: "CLI/MCP server" → "Search CLI"
- ✅ ドキュメント内の git clone URL とディレクトリ名を更新

## 技術的な改善

- コード重複削除: setup-data.sh の関数化（download_file, verify_file_size）
- 言語統一: ドキュメント全体を日本語で統一
- 表記ゆれ修正: {{name|cardId}} に統一

## リリース情報

- v1.3.0 タグ作成済み
- GitHub Releases で公開済み
  - アセット: cards-all.tsv, detail-all.tsv, faq-all.tsv

## テスト状況

- ✅ テスト全95個合格
- ✅ ドキュメント変更のみ（機能への影響なし）

## マージ後の作業

- v1.3.0 を本番環境にリリース
- ローカルディレクトリ名を YuGiOh-Search-CLI に変更（必要に応じて）