### PR TITLE
feat: Vector検索機能の実装とドキュメント整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Command-line tools for searching Yu-Gi-Oh! card database locally with full Japan
 ### CLI Commands
 
 - **ygo_search** - Search cards with flexible filters
+- **ygo_search vector** - Vector search (semantic search) for cards, FAQs, and rules
 - **ygo_bulk_search** - Efficient bulk search (up to 50 queries)
 - **ygo_extract** - Extract card patterns from text
 - **ygo_replace** - Extract and replace patterns with card IDs or names
@@ -45,6 +46,14 @@ Automatically handles:
 - Filter by FAQ ID, card ID, card name patterns
 - Search by card specifications (race, level, type, etc.)
 - Search question/answer text with wildcards
+
+### Vector Search (Semantic Search)
+
+- **Semantic search**: Find cards, FAQs, and rules by meaning, not just keywords
+- **Multi-table search**: Search across cards, FAQs, and custom tables simultaneously
+- **Custom data import**: Import any YAML/JSON/JSONL/TSV/CSV data with id/title/text fields
+- **Hierarchy support**: Automatically extracts and includes hierarchical paths from YAML/JSON
+- **Multilingual embeddings**: Uses multilingual-e5-small model for accurate semantic matching
 
 ## Installation
 
@@ -102,6 +111,11 @@ ygo_faq_search cardId=6808 limit=5
 ygo_faq_search cardName="青眼*" limit=10
 ygo_faq_search question="*シンクロ召喚*"
 
+# Vector search (semantic search)
+ygo_search vector setup all                         # Setup vector DB
+ygo_search vector search "墓地から特殊召喚"          # Search all tables
+ygo_search vector search "チェーン" --type rules --limit 5
+
 # Update/download card database
 ygo_update_search
 
@@ -116,6 +130,80 @@ node dist/cli/ygo_search.js '{"name":"青眼"}' cols=name,cardId
 node dist/cli/ygo_extract.js "{青眼の白龍}"
 node dist/cli/ygo_replace.js "{青眼}を召喚" --raw
 node dist/cli/ygo_convert.js input.json:output.csv
+```
+
+### Library Usage (TypeScript/JavaScript)
+
+```typescript
+import {
+  // Card search
+  searchCards,
+
+  // FAQ search
+  searchFAQ,
+
+  // Pattern extraction and replacement
+  extractCardPatterns,
+  extractAndSearchCards,
+  judgeAndReplace,
+
+  // Card retrieval
+  seekCards,
+
+  // Format conversion
+  convertFormatFile,
+  formatOutput,
+  parseFormatString,
+
+  // Vector search
+  vectorSearchCards,
+  vectorSearchFaqs,
+  vectorSearchAll,
+  searchTable,
+  listTables,
+
+  // Vector DB setup
+  convertCardsToJsonl,
+  convertFaqsToJsonl,
+  convertGenericToJsonl,
+  indexFromJsonl
+} from 'ygo-search'
+
+// Card search
+const cards = await searchCards({
+  filter: { name: '青眼の白龍' },
+  cols: ['name', 'cardId', 'text']
+})
+
+// FAQ search
+const faqs = await searchFAQ({
+  cardName: '青眼の白龍',
+  limit: 10
+})
+
+// Pattern extraction
+const patterns = extractCardPatterns('{ブルーアイズ*}と《青眼の白龍》')
+
+// Pattern search
+const results = await extractAndSearchCards('{ブルーアイズ*}を召喚')
+
+// Pattern replacement
+const replaced = await judgeAndReplace('{青眼の白龍}を召喚', {
+  replaceFormat: 'id-in-brace'
+})
+
+// Random card retrieval
+const randomCards = await seekCards({ max: 10 })
+
+// Vector search (semantic search)
+const vectorResults = await vectorSearchAll('墓地から特殊召喚', { limit: 5 })
+
+// Custom table search
+const rulesResults = await searchTable('rules', 'チェーンブロック', { limit: 5 })
+
+// Format conversion
+await convertFormatFile('input.json', 'output.csv')
+const yamlString = formatOutput({ key: 'value' }, 'yaml')
 ```
 
 ## Database

--- a/dist/cli/ygo_search.js
+++ b/dist/cli/ygo_search.js
@@ -4,6 +4,7 @@ import path from 'path';
 import url from 'url';
 import { extractAndSearchCards } from '../lib/extract-and-search-cards.js';
 import { judgeAndReplace } from '../lib/judge-and-replace.js';
+import { getTsvPath, getTmpPath, getTmpDir } from '../lib/config/paths.js';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 // カラム定義（旧 ygo_search.ts から）
 const COLUMN_DEFINITIONS = {
@@ -315,6 +316,7 @@ Commands:
   seek [options]        ランダムカード取得
   bulk [queries]        複数クエリを一括検索
   convert <in:out>      フォーマット変換（JSON/JSONL/YAML）
+  vector setup [type]   Vector DBセットアップ（cards/faqs/all）
   update                データ更新
   help                  このヘルプを表示
 
@@ -625,6 +627,358 @@ function handleSeekCommand(args) {
         process.exit(code || 0);
     });
 }
+// vector サブコマンド
+async function handleVectorCommand(args) {
+    if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+        console.log(`Usage: ygo_search vector <subcommand> [options]
+
+Vector DB管理コマンド
+
+Subcommands:
+  setup [type]          Vector DBインデックスを構築（cards/faqs）
+                        type: cards, faqs, all (デフォルト: all)
+                        Options:
+                          --keep-tmp    一時JSONLファイルを削除せずに保持
+  setup-generic <file> <table>  汎用データをインポート
+                        file: yaml/jsonl/json/tsv/csv
+                        table: テーブル名
+                        Options:
+                          --exclude-columns col1,col2
+                          --include-columns col1,col2
+                          --keep-tmp
+  search <query>        Vector検索を実行
+
+Examples:
+  ygo_search vector setup                全てのインデックスを構築
+  ygo_search vector setup cards          カードのみ
+  ygo_search vector setup faqs           FAQのみ
+  ygo_search vector setup --keep-tmp     一時ファイルを保持
+  ygo_search vector setup-generic rules.yml rules --exclude-columns cite
+  ygo_search vector setup-generic data.json custom --include-columns category
+  ygo_search vector search "墓地から特殊召喚" --limit 5
+  ygo_search vector search "融合召喚" --type cards --threshold 0.8
+`);
+        process.exit(0);
+    }
+    const subcommand = args[0];
+    const subArgs = args.slice(1);
+    if (subcommand === 'setup') {
+        await handleVectorSetupCommand(subArgs);
+    } else if (subcommand === 'setup-generic') {
+        await handleVectorSetupGenericCommand(subArgs);
+    } else if (subcommand === 'search') {
+        await handleVectorSearchCommand(subArgs);
+    } else {
+        console.error(`Unknown vector subcommand: ${subcommand}`);
+        process.exit(1);
+    }
+}
+async function handleVectorSetupCommand(args) {
+    const { convertCardsToJsonl, convertFaqsToJsonl } = await import('../lib/vector/converter.js');
+    const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+    const fs = await import('fs/promises');
+    // オプション解析
+    let type = 'all';
+    let keepTmp = false;
+    for(let i = 0; i < args.length; i++){
+        const arg = args[i];
+        if (arg === '--keep-tmp') {
+            keepTmp = true;
+        } else if (!arg.startsWith('--')) {
+            type = arg;
+        }
+    }
+    if (![
+        'cards',
+        'faqs',
+        'all'
+    ].includes(type)) {
+        console.error(`Invalid type: ${type}. Must be one of: cards, faqs, all`);
+        process.exit(1);
+    }
+    // tmpファイルのパスを保持
+    const tmpFiles = [];
+    // SIGINT対応
+    let interrupted = false;
+    process.on('SIGINT', async ()=>{
+        console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
+        interrupted = true;
+        try {
+            await cleanupTempTables();
+            console.error('クリーンアップ完了。既存のデータは保持されています。');
+        } catch (e) {
+            console.error('クリーンアップ中にエラー:', e);
+        }
+        process.exit(130);
+    });
+    try {
+        // 一時ディレクトリ作成
+        const tmpDir = getTmpDir();
+        await fs.mkdir(tmpDir, {
+            recursive: true
+        });
+        if (type === 'all' || type === 'cards') {
+            if (interrupted) return;
+            console.error('\n=== Cards のインデックス構築 ===');
+            const cardsTsvPath = getTsvPath('cards-all.tsv');
+            const detailTsvPath = getTsvPath('detail-all.tsv');
+            const cardsJsonlPath = getTmpPath('cards_for_vectordb.jsonl');
+            tmpFiles.push(cardsJsonlPath);
+            console.error('TSVからJSONLに変換中...');
+            const cardsCount = await convertCardsToJsonl(cardsTsvPath, detailTsvPath, cardsJsonlPath);
+            console.error(`${cardsCount}件のカードを変換しました`);
+            console.error('Vector DBインデックスを構築中...');
+            await indexFromJsonl('cards', cardsJsonlPath);
+        }
+        if (type === 'all' || type === 'faqs') {
+            if (interrupted) return;
+            console.error('\n=== FAQs のインデックス構築 ===');
+            const faqsTsvPath = getTsvPath('faq-all.tsv');
+            const faqsJsonlPath = getTmpPath('faqs_for_vectordb.jsonl');
+            tmpFiles.push(faqsJsonlPath);
+            console.error('TSVからJSONLに変換中...');
+            const faqsCount = await convertFaqsToJsonl(faqsTsvPath, faqsJsonlPath);
+            console.error(`${faqsCount}件のFAQを変換しました`);
+            console.error('Vector DBインデックスを構築中...');
+            await indexFromJsonl('faqs', faqsJsonlPath);
+        }
+        console.error('\n全てのインデックス構築が完了しました');
+        // tmpファイルのクリーンアップ
+        if (!keepTmp && tmpFiles.length > 0) {
+            console.error('\n一時ファイルをクリーンアップ中...');
+            for (const tmpFile of tmpFiles){
+                try {
+                    await fs.unlink(tmpFile);
+                    console.error(`削除: ${tmpFile}`);
+                } catch (e) {
+                    if (e.code !== 'ENOENT') {
+                        console.error(`警告: ${tmpFile} の削除に失敗しました:`, e.message);
+                    }
+                }
+            }
+            console.error('クリーンアップ完了');
+        } else if (keepTmp) {
+            console.error('\n--keep-tmpオプションが指定されているため、一時ファイルを保持します');
+        }
+    } catch (error) {
+        console.error('インデックス構築中にエラーが発生しました:', error.message);
+        process.exit(1);
+    }
+}
+async function handleVectorSearchCommand(args) {
+    if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+        console.log(`Usage: ygo_search vector search <query> [options]
+
+Vector検索を実行
+
+Arguments:
+  query                 検索クエリ
+
+Options:
+  --type TYPE           検索対象（cards/faqs/all/カスタムテーブル名, デフォルト: all）
+  --limit N             最大結果数（デフォルト: 10）
+  --threshold N         スコア閾値（0.0-1.0, 小さいほど厳密）
+  --distance TYPE       距離メトリック（cosine/l2/dot, デフォルト: cosine）
+  --format FORMAT       出力形式（json/csv/tsv/jsonl, デフォルト: json）
+
+Examples:
+  ygo_search vector search "墓地から特殊召喚"
+  ygo_search vector search "融合召喚" --type cards --limit 5
+  ygo_search vector search "カウンター罠" --threshold 0.7
+  ygo_search vector search "チェーンブロック" --format jsonl
+  ygo_search vector search "特殊召喚" --type test
+`);
+        process.exit(0);
+    }
+    const query = args[0];
+    if (!query) {
+        console.error('Error: クエリを指定してください');
+        process.exit(1);
+    }
+    const { searchCards, searchFaqs, searchAll, searchTable } = await import('../lib/vector/searcher.js');
+    // オプション解析
+    let type = 'all';
+    let limit = 10;
+    let threshold = undefined;
+    let distanceType = 'cosine';
+    let format = 'json';
+    for(let i = 1; i < args.length; i++){
+        if (args[i] === '--type' && i + 1 < args.length) {
+            type = args[++i];
+        } else if (args[i] === '--limit' && i + 1 < args.length) {
+            limit = parseInt(args[++i], 10);
+        } else if (args[i] === '--threshold' && i + 1 < args.length) {
+            threshold = parseFloat(args[++i]);
+        } else if (args[i] === '--distance' && i + 1 < args.length) {
+            distanceType = args[++i];
+        } else if (args[i] === '--format' && i + 1 < args.length) {
+            format = args[++i];
+        }
+    }
+    const options = {
+        limit,
+        threshold,
+        distanceType
+    };
+    try {
+        console.error(`検索中: "${query}"\n`);
+        let results;
+        if (type === 'cards') {
+            const cards = await searchCards(query, options);
+            results = {
+                cards
+            };
+        } else if (type === 'faqs') {
+            const faqs = await searchFaqs(query, options);
+            results = {
+                faqs
+            };
+        } else if (type === 'all') {
+            results = await searchAll(query, options);
+        } else {
+            // カスタムテーブルの検索
+            const customResults = await searchTable(type, query, options);
+            results = {
+                [type]: customResults
+            };
+        }
+        // フォーマット出力
+        if (format === 'json') {
+            console.log(JSON.stringify(results, null, 2));
+        } else if (format === 'jsonl') {
+            // 全ての結果を配列に集める
+            const allResults = Object.values(results).flat();
+            for (const r of allResults){
+                console.log(JSON.stringify(r));
+            }
+        } else if (format === 'csv' || format === 'tsv') {
+            const sep = format === 'csv' ? ',' : '\t';
+            // 全ての結果を配列に集める
+            const allResults = Object.values(results).flat();
+            if (allResults.length > 0) {
+                console.log([
+                    'id',
+                    'score',
+                    'text_preview'
+                ].join(sep));
+                for (const r of allResults){
+                    const textPreview = r.text.substring(0, 100).replace(/\n/g, ' ');
+                    console.log([
+                        r.id,
+                        r.score.toFixed(4),
+                        `"${textPreview}..."`
+                    ].join(sep));
+                }
+            }
+        }
+    } catch (error) {
+        console.error('検索エラー:', error.message);
+        process.exit(1);
+    }
+}
+async function handleVectorSetupGenericCommand(args) {
+    if (args.length < 2 || args[0] === '--help' || args[0] === '-h') {
+        console.log(`Usage: ygo_search vector setup-generic <inputFile> <tableName> [options]
+
+汎用データからVector DBインデックスを構築
+
+Arguments:
+  inputFile             入力ファイル（yaml/jsonl/json/tsv/csv）
+  tableName             テーブル名
+
+Options:
+  --exclude-columns col1,col2    指定カラムをテキストから除外
+  --include-columns col1,col2    指定カラムのみテキストに含める
+  --keep-tmp                     一時JSONLファイルを削除せずに保持
+
+Required fields: id, title, text
+
+Examples:
+  ygo_search vector setup-generic rules.yml rules
+  ygo_search vector setup-generic data.json custom --exclude-columns cite,sourceFile
+  ygo_search vector setup-generic items.tsv items --include-columns category,priority
+`);
+        process.exit(0);
+    }
+    const { convertGenericToJsonl } = await import('../lib/vector/converter.js');
+    const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+    const fs = await import('fs/promises');
+    const inputFile = args[0];
+    const tableName = args[1];
+    // オプション解析
+    let excludeColumns = undefined;
+    let includeColumns = undefined;
+    let keepTmp = false;
+    for(let i = 2; i < args.length; i++){
+        if (args[i] === '--exclude-columns' && i + 1 < args.length) {
+            excludeColumns = args[++i].split(',').map((c)=>c.trim());
+        } else if (args[i] === '--include-columns' && i + 1 < args.length) {
+            includeColumns = args[++i].split(',').map((c)=>c.trim());
+        } else if (args[i] === '--keep-tmp') {
+            keepTmp = true;
+        }
+    }
+    // Validate exclusivity
+    if (excludeColumns && includeColumns) {
+        console.error('Error: Cannot specify both --exclude-columns and --include-columns');
+        process.exit(1);
+    }
+    const tmpFiles = [];
+    // SIGINT対応
+    let interrupted = false;
+    process.on('SIGINT', async ()=>{
+        console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
+        interrupted = true;
+        try {
+            await cleanupTempTables();
+            console.error('クリーンアップ完了。既存のデータは保持されています。');
+        } catch (e) {
+            console.error('クリーンアップ中にエラー:', e);
+        }
+        process.exit(130);
+    });
+    try {
+        // 一時ディレクトリ作成
+        const tmpDir = getTmpDir();
+        await fs.mkdir(tmpDir, {
+            recursive: true
+        });
+        console.error(`\n=== ${tableName} のインデックス構築 ===`);
+        const jsonlPath = getTmpPath(`${tableName}_for_vectordb.jsonl`);
+        tmpFiles.push(jsonlPath);
+        console.error(`${inputFile} からJSONLに変換中...`);
+        const options = excludeColumns ? {
+            excludeColumns
+        } : includeColumns ? {
+            includeColumns
+        } : undefined;
+        const count = await convertGenericToJsonl(inputFile, jsonlPath, options);
+        console.error(`${count}件のレコードを変換しました`);
+        console.error('Vector DBインデックスを構築中...');
+        await indexFromJsonl(tableName, jsonlPath);
+        console.error('\nインデックス構築が完了しました');
+        // tmpファイルのクリーンアップ
+        if (!keepTmp && tmpFiles.length > 0) {
+            console.error('\n一時ファイルをクリーンアップ中...');
+            for (const tmpFile of tmpFiles){
+                try {
+                    await fs.unlink(tmpFile);
+                    console.error(`削除: ${tmpFile}`);
+                } catch (e) {
+                    if (e.code !== 'ENOENT') {
+                        console.error(`警告: ${tmpFile} の削除に失敗しました:`, e.message);
+                    }
+                }
+            }
+            console.error('クリーンアップ完了');
+        } else if (keepTmp) {
+            console.error('\n--keep-tmpオプションが指定されているため、一時ファイルを保持します');
+        }
+    } catch (error) {
+        console.error('インデックス構築中にエラーが発生しました:', error.message);
+        process.exit(1);
+    }
+}
 // update サブコマンド（旧 ygo_update_search）
 function handleUpdateCommand() {
     const scriptPath = path.join(__dirname, 'ygo_update_search.js');
@@ -666,6 +1020,9 @@ async function main() {
             break;
         case 'convert':
             handleConvertCommand(commandArgs);
+            break;
+        case 'vector':
+            await handleVectorCommand(commandArgs);
             break;
         case 'update':
             handleUpdateCommand();

--- a/dist/cli/ygo_search.js
+++ b/dist/cli/ygo_search.js
@@ -6,6 +6,25 @@ import { extractAndSearchCards } from '../lib/extract-and-search-cards.js';
 import { judgeAndReplace } from '../lib/judge-and-replace.js';
 import { getTsvPath, getTmpPath, getTmpDir } from '../lib/config/paths.js';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+// SIGINT ハンドラをセットアップする共通ヘルパー
+function setupInterruptHandler() {
+    const state = {
+        interrupted: false
+    };
+    process.on('SIGINT', async ()=>{
+        console.error('\n\n中断を検出しました。処理を終了します...');
+        state.interrupted = true;
+        process.exit(130);
+    });
+    return {
+        get interrupted () {
+            return state.interrupted;
+        },
+        setInterrupted (value) {
+            state.interrupted = value;
+        }
+    };
+}
 // カラム定義（旧 ygo_search.ts から）
 const COLUMN_DEFINITIONS = {
     // Basic information
@@ -675,7 +694,7 @@ Examples:
 }
 async function handleVectorSetupCommand(args) {
     const { convertCardsToJsonl, convertFaqsToJsonl } = await import('../lib/vector/converter.js');
-    const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+    const { indexFromJsonl } = await import('../lib/vector/indexer.js');
     const fs = await import('fs/promises');
     // オプション解析
     let type = 'all';
@@ -699,18 +718,7 @@ async function handleVectorSetupCommand(args) {
     // tmpファイルのパスを保持
     const tmpFiles = [];
     // SIGINT対応
-    let interrupted = false;
-    process.on('SIGINT', async ()=>{
-        console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
-        interrupted = true;
-        try {
-            await cleanupTempTables();
-            console.error('クリーンアップ完了。既存のデータは保持されています。');
-        } catch (e) {
-            console.error('クリーンアップ中にエラー:', e);
-        }
-        process.exit(130);
-    });
+    const { interrupted } = setupInterruptHandler();
     try {
         // 一時ディレクトリ作成
         const tmpDir = getTmpDir();
@@ -862,7 +870,7 @@ Examples:
                     'text_preview'
                 ].join(sep));
                 for (const r of allResults){
-                    const textPreview = r.text.substring(0, 100).replace(/\n/g, ' ');
+                    const textPreview = r.text.substring(0, 100).replace(/\n/g, ' ').replace(/"/g, '""');
                     console.log([
                         r.id,
                         r.score.toFixed(4),
@@ -901,7 +909,7 @@ Examples:
         process.exit(0);
     }
     const { convertGenericToJsonl } = await import('../lib/vector/converter.js');
-    const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+    const { indexFromJsonl } = await import('../lib/vector/indexer.js');
     const fs = await import('fs/promises');
     const inputFile = args[0];
     const tableName = args[1];
@@ -925,18 +933,7 @@ Examples:
     }
     const tmpFiles = [];
     // SIGINT対応
-    let interrupted = false;
-    process.on('SIGINT', async ()=>{
-        console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
-        interrupted = true;
-        try {
-            await cleanupTempTables();
-            console.error('クリーンアップ完了。既存のデータは保持されています。');
-        } catch (e) {
-            console.error('クリーンアップ中にエラー:', e);
-        }
-        process.exit(130);
-    });
+    const { interrupted } = setupInterruptHandler();
     try {
         // 一時ディレクトリ作成
         const tmpDir = getTmpDir();

--- a/dist/lib/card-search-core.js
+++ b/dist/lib/card-search-core.js
@@ -2,9 +2,8 @@
  * Core card search logic extracted for library use
  * Used by both CLI (search-cards.ts) and FAQ search (search-faq.ts)
  */ import fs from 'fs';
-import path from 'path';
 import readline from 'readline';
-import { findProjectRoot } from '../utils/project-root.js';
+import { getTsvPath } from './config/paths.js';
 function normalizeForSearch(str) {
     if (!str) return '';
     return str.replace(/[\s\u3000]+/g, '').replace(/[・★☆※‼！？。、,.，．:：;；「」『』【】〔〕（）()［］\[\]｛｝{}〈〉《》〜～~\-－_＿\/／\\＼|｜&＆@＠#＃$＄%％^＾*＊+＋=＝<＜>＞'"\"'""''`´｀]/g, '').replace(/竜/g, '龍').replace(/剣/g, '劍').replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s)=>String.fromCharCode(s.charCodeAt(0) - 0xFEE0)).toLowerCase().replace(/[\u3041-\u3096]/g, (s)=>String.fromCharCode(s.charCodeAt(0) + 0x60));
@@ -86,9 +85,7 @@ function valueMatches(fieldValue, cond, mode, flagAutoModify, isNameField, norma
             };
         }
     }
-    const projectRoot = await findProjectRoot();
-    const dataDir = path.join(projectRoot, 'data');
-    const cardsFile = path.join(dataDir, 'cards-all.tsv');
+    const cardsFile = getTsvPath('cards-all.tsv');
     if (!fs.existsSync(cardsFile)) {
         throw new Error(`カードデータファイルが見つかりません: ${cardsFile}\n\n以下のコマンドでデータをダウンロードしてください:\n  ygo_update_search`);
     }

--- a/dist/search-cards.js
+++ b/dist/search-cards.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 import fs from 'fs';
-import path from 'path';
-import url from 'url';
-import { findProjectRoot } from './utils/project-root.js';
 // Usage:
 // Single mode: node search-cards.ts '{"name":"アシスト"}' cols=name,cardId mode=exact
 // Bulk mode: node search-cards.ts --bulk '[{"filter":{"name":"青眼"},"cols":["name"]},{"filter":{"name":"ブラマジ"},"cols":["name"]}]'
@@ -452,14 +449,12 @@ async function main() {
             process.exit(2);
         }
     }
-    // Find project root (where package.json is)
-    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-    const projectRoot = await findProjectRoot(__dirname);
-    const dataDir = path.join(projectRoot, 'data');
-    const cardsFile = path.join(dataDir, 'cards-all.tsv');
-    const detailFile = path.join(dataDir, 'detail-all.tsv');
+    // Get TSV file paths
+    const { getTsvPath } = await import('./lib/config/paths.js');
+    const cardsFile = getTsvPath('cards-all.tsv');
+    const detailFile = getTsvPath('detail-all.tsv');
     if (!fs.existsSync(cardsFile) || !fs.existsSync(detailFile)) {
-        console.error(`data files not found at ${dataDir}`);
+        console.error(`data files not found: ${cardsFile}, ${detailFile}`);
         process.exit(2);
     }
     const rl = readline.createInterface({

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -191,6 +191,386 @@ ygo_convert a.json:a.csv b.jsonl:b.tsv c.csv:c.json
 # Supported formats: .json, .jsonl, .csv, .tsv
 ```
 
+### ygo_search vector - Vector Search (Semantic Search)
+
+Vector検索機能は、意味的な類似性に基づいてカード、FAQ、ルールを検索します。
+
+#### セットアップ
+
+```bash
+# カード・FAQのVector DBインデックス構築
+ygo_search vector setup cards    # カードのみ
+ygo_search vector setup faqs     # FAQのみ
+ygo_search vector setup all      # 全て
+
+# ルールデータのインポート（YAML形式）
+ygo_search vector setup-generic rules.yml rules --include-columns name,notes,examples
+
+# 汎用データのインポート（yaml/json/jsonl/tsv/csv対応）
+ygo_search vector setup-generic data.json custom-table
+```
+
+#### 検索
+
+```bash
+# 全テーブルを検索（cards, faqs, rules全て）
+ygo_search vector search "墓地から特殊召喚"
+
+# 特定テーブルのみ検索
+ygo_search vector search "チェーンブロック" --type cards
+ygo_search vector search "効果の発動タイミング" --type faqs
+ygo_search vector search "ターンの流れ" --type rules
+
+# 結果数の制限
+ygo_search vector search "融合召喚" --limit 5
+
+# スコア閾値による絞り込み
+ygo_search vector search "シンクロ召喚" --threshold 0.7
+
+# 出力フォーマット指定
+ygo_search vector search "ドラゴン" --format json
+ygo_search vector search "ドラゴン" --format jsonl
+ygo_search vector search "ドラゴン" --format csv
+ygo_search vector search "ドラゴン" --format tsv
+
+# 距離メトリック指定
+ygo_search vector search "墓地" --distance cosine  # デフォルト
+ygo_search vector search "墓地" --distance l2
+ygo_search vector search "墓地" --distance dot
+```
+
+#### 汎用データインポートの詳細
+
+```bash
+# 必須フィールド: id, title, text
+# その他のフィールドは自動的に検索テキストに含まれる
+
+# 特定カラムのみ含める
+ygo_search vector setup-generic data.yml table --include-columns name,notes,examples
+
+# 特定カラムを除外
+ygo_search vector setup-generic data.json table --exclude-columns cite,sourceFile
+
+# 一時JSONLファイルを保持（デバッグ用）
+ygo_search vector setup-generic data.yml table --keep-tmp
+
+# 対応フォーマット:
+# - YAML (.yml, .yaml) - 階層構造から自動抽出
+# - JSON (.json)       - 階層構造から自動抽出
+# - JSONL (.jsonl)     - 1行1レコード
+# - TSV (.tsv)         - タブ区切り（ヘッダー必須）
+# - CSV (.csv)         - カンマ区切り（ヘッダー必須）
+```
+
+#### Vector検索の特徴
+
+- **意味的検索**: キーワードの完全一致ではなく、意味の類似性で検索
+- **多言語対応**: multilingual-e5-smallモデルを使用
+- **階層構造対応**: YAML/JSONの階層パスが自動的に検索テキストに含まれる
+- **並列検索**: 複数テーブルを並列に高速検索
+- **カスタムテーブル**: 任意のデータをインポート可能
+
+#### 検索結果の例
+
+```json
+{
+  "cards": [
+    {
+      "id": "card-6808",
+      "text": "【カード名】 青眼の白龍\n...",
+      "metadata": { "cardId": 6808, "cardType": "monster" },
+      "score": 0.15
+    }
+  ],
+  "faqs": [
+    {
+      "id": "faq-123",
+      "text": "# 質問\n...\n# 回答\n...",
+      "metadata": { "faqId": 123 },
+      "score": 0.18
+    }
+  ],
+  "rules": [
+    {
+      "id": "EC07",
+      "text": "【効果の解決】\n【階層】\nEffectsAndChains > Resolution\n...",
+      "metadata": { "id": "EC07" },
+      "score": 0.12
+    }
+  ]
+}
+```
+
+## Library Usage (TypeScript/JavaScript)
+
+ygo-searchはライブラリとしてプログラムから利用することもできます。
+
+### インストール
+
+```bash
+npm install ygo-search
+# または
+bun add ygo-search
+```
+
+### 基本的な使用例
+
+#### カード検索
+
+```typescript
+import { searchCards, type CardSearchParams } from 'ygo-search'
+
+// 基本検索
+const cards = await searchCards({
+  filter: { name: '青眼の白龍' },
+  cols: ['name', 'cardId', 'text']
+})
+
+// ワイルドカード検索
+const dragons = await searchCards({
+  filter: { name: 'ブルーアイズ*', race: 'ドラゴン族' },
+  cols: ['name', 'atk', 'def']
+})
+
+// 部分一致検索
+const partial = await searchCards({
+  filter: { text: '破壊' },
+  mode: 'partial',
+  cols: ['name', 'text']
+})
+```
+
+#### FAQ検索
+
+```typescript
+import { searchFAQ, type SearchFAQParams } from 'ygo-search'
+
+// カードIDでFAQ検索
+const faqs = await searchFAQ({
+  cardId: 6808,
+  limit: 10
+})
+
+// カード名でFAQ検索
+const faqsByName = await searchFAQ({
+  cardName: '青眼*',
+  limit: 20
+})
+
+// 質問文で検索
+const faqsByQuestion = await searchFAQ({
+  question: '*シンクロ召喚*',
+  limit: 10
+})
+```
+
+#### パターン抽出と置換
+
+```typescript
+import {
+  extractCardPatterns,
+  extractAndSearchCards,
+  judgeAndReplace
+} from 'ygo-search'
+
+// パターン抽出
+const patterns = extractCardPatterns('{ブルーアイズ*}と《青眼の白龍》')
+// [
+//   { pattern: '{ブルーアイズ*}', type: 'flexible', query: 'ブルーアイズ*' },
+//   { pattern: '《青眼の白龍》', type: 'exact', query: '青眼の白龍' }
+// ]
+
+// パターン抽出と検索
+const results = await extractAndSearchCards('{ブルーアイズ*}を召喚')
+
+// パターン判定と置換
+const replaced = await judgeAndReplace('{青眼の白龍}を召喚', {
+  replaceFormat: 'id-in-brace'  // {{カード名|カードID}}形式
+})
+
+const replacedName = await judgeAndReplace('{青眼の白龍}を召喚', {
+  replaceFormat: 'name-in-mount-par'  // 《カード名》形式
+})
+```
+
+#### ランダム/範囲指定カード取得
+
+```typescript
+import { seekCards, type SeekCardsOptions } from 'ygo-search'
+
+// ランダムに10件取得
+const randomCards = await seekCards({ max: 10 })
+
+// 範囲指定で取得
+const rangeCards = await seekCards({
+  range: [4000, 5000],
+  max: 20,
+  cols: ['name', 'cardId', 'atk', 'def']
+})
+
+// ランダム順でなく順番通りに取得
+const orderedCards = await seekCards({
+  range: [4000, 4100],
+  noRandom: true,
+  max: 50
+})
+```
+
+#### フォーマット変換
+
+```typescript
+import {
+  convertFormatFile,
+  formatOutput,
+  parseFormatString,
+  detectFormat
+} from 'ygo-search'
+
+// ファイル変換
+await convertFormatFile('input.json', 'output.csv')
+await convertFormatFile('input.jsonl', 'output.yaml')
+
+// データ変換
+const yamlString = formatOutput({ key: 'value', data: [1, 2, 3] }, 'yaml')
+const csvString = formatOutput([{ name: 'card1' }, { name: 'card2' }], 'csv')
+
+// パース
+const data = parseFormatString('{"key":"value"}', 'json')
+const yamlData = parseFormatString('key: value\ndata:\n  - 1\n  - 2', 'yaml')
+
+// フォーマット自動検出
+const format = detectFormat('data.jsonl')  // 'jsonl'
+```
+
+### Vector検索（意味的検索）
+
+#### Vector DBセットアップ
+
+```typescript
+import {
+  convertCardsToJsonl,
+  convertFaqsToJsonl,
+  convertGenericToJsonl,
+  indexFromJsonl
+} from 'ygo-search'
+
+// カードデータをVector DB用に変換
+const cardCount = await convertCardsToJsonl(
+  'data/cards-all.tsv',
+  'data/detail-all.tsv',
+  'tmp/cards.jsonl'
+)
+
+// FAQデータをVector DB用に変換
+const faqCount = await convertFaqsToJsonl(
+  'data/faq-all.tsv',
+  'tmp/faqs.jsonl'
+)
+
+// 汎用データをVector DB用に変換
+const genericCount = await convertGenericToJsonl(
+  'rules.yml',
+  'tmp/rules.jsonl',
+  {
+    includeColumns: ['name', 'notes', 'examples']  // 特定カラムのみ含める
+    // または
+    // excludeColumns: ['cite', 'sourceFile']  // 特定カラムを除外
+  }
+)
+
+// Vector DBインデックス構築
+await indexFromJsonl('cards', 'tmp/cards.jsonl')
+await indexFromJsonl('faqs', 'tmp/faqs.jsonl')
+await indexFromJsonl('rules', 'tmp/rules.jsonl')
+```
+
+#### Vector検索
+
+```typescript
+import {
+  vectorSearchCards,
+  vectorSearchFaqs,
+  vectorSearchAll,
+  searchTable,
+  listTables,
+  type VectorSearchOptions,
+  type VectorSearchResult
+} from 'ygo-search'
+
+// カードをVector検索
+const cards = await vectorSearchCards('墓地から特殊召喚', {
+  limit: 10,
+  threshold: 0.7,      // スコア閾値
+  distanceType: 'cosine'  // cosine / l2 / dot
+})
+
+// FAQをVector検索
+const faqs = await vectorSearchFaqs('チェーンブロック', {
+  limit: 5
+})
+
+// 全テーブルを検索（cards, faqs, rulesなど全て）
+const allResults = await vectorSearchAll('融合召喚', {
+  limit: 10
+})
+// 結果: { cards: [...], faqs: [...], rules: [...] }
+
+// カスタムテーブルを検索
+const rulesResults = await searchTable('rules', 'ターンの流れ', {
+  limit: 5,
+  threshold: 0.6
+})
+
+// 利用可能なテーブル一覧を取得
+const tables = await listTables()
+// ['cards', 'faqs', 'rules', ...]
+
+// 検索結果の型
+interface VectorSearchResult {
+  id: string
+  text: string
+  metadata: Record<string, any>
+  score: number  // 距離スコア（小さいほど類似）
+}
+```
+
+### 型定義
+
+ライブラリは完全な型定義を提供しています：
+
+```typescript
+import type {
+  // Card types
+  Card,
+  CardDetail,
+  CardSearchParams,
+
+  // FAQ types
+  FAQRecord,
+  SearchFAQParams,
+
+  // Pattern types
+  ExtractedPattern,
+  ReplacementResult,
+
+  // Vector search types
+  VectorSearchResult,
+  VectorSearchOptions,
+  VectorRecord,
+  GenericConversionOptions,
+
+  // Format types
+  Format
+} from 'ygo-search'
+```
+
+### 環境変数
+
+```typescript
+// データディレクトリをカスタマイズ
+process.env.YGO_SEARCH_WORKDIR = './custom-data'
+```
+
 ## Advanced Usage
 
 ### Search Pattern Normalization

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -260,6 +260,8 @@ ygo_search vector setup-generic data.yml table --keep-tmp
 # - JSONL (.jsonl)     - 1行1レコード
 # - TSV (.tsv)         - タブ区切り（ヘッダー必須）
 # - CSV (.csv)         - カンマ区切り（ヘッダー必須）
+#                        注: 値にカンマが含まれる場合は正しく処理されません。
+#                        複雑なCSVの場合はTSVまたはJSON形式を推奨します。
 ```
 
 #### Vector検索の特徴

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@lancedb/lancedb": "^0.23.0",
+    "@xenova/transformers": "^2.17.2",
     "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.1",
     "tsx": "^4.20.6",

--- a/src/cli/ygo_search.ts
+++ b/src/cli/ygo_search.ts
@@ -7,6 +7,7 @@ import { searchFAQ, type SearchFAQParams } from '../search-faq.js';
 import { extractAndSearchCards } from '../lib/extract-and-search-cards.js';
 import { judgeAndReplace, type JudgeAndReplaceOptions } from '../lib/judge-and-replace.js';
 import { seekCards, type SeekCardsOptions } from '../lib/seek-cards.js';
+import { getTsvPath, getTmpPath, getTmpDir } from '../lib/config/paths.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -207,6 +208,7 @@ Commands:
   seek [options]        ランダムカード取得
   bulk [queries]        複数クエリを一括検索
   convert <in:out>      フォーマット変換（JSON/JSONL/YAML）
+  vector setup [type]   Vector DBセットアップ（cards/faqs/all）
   update                データ更新
   help                  このヘルプを表示
 
@@ -523,6 +525,379 @@ function handleSeekCommand(args: string[]) {
   });
 }
 
+// vector サブコマンド
+async function handleVectorCommand(args: string[]) {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(`Usage: ygo_search vector <subcommand> [options]
+
+Vector DB管理コマンド
+
+Subcommands:
+  setup [type]          Vector DBインデックスを構築（cards/faqs）
+                        type: cards, faqs, all (デフォルト: all)
+                        Options:
+                          --keep-tmp    一時JSONLファイルを削除せずに保持
+  setup-generic <file> <table>  汎用データをインポート
+                        file: yaml/jsonl/json/tsv/csv
+                        table: テーブル名
+                        Options:
+                          --exclude-columns col1,col2
+                          --include-columns col1,col2
+                          --keep-tmp
+  search <query>        Vector検索を実行
+
+Examples:
+  ygo_search vector setup                全てのインデックスを構築
+  ygo_search vector setup cards          カードのみ
+  ygo_search vector setup faqs           FAQのみ
+  ygo_search vector setup --keep-tmp     一時ファイルを保持
+  ygo_search vector setup-generic rules.yml rules --exclude-columns cite
+  ygo_search vector setup-generic data.json custom --include-columns category
+  ygo_search vector search "墓地から特殊召喚" --limit 5
+  ygo_search vector search "融合召喚" --type cards --threshold 0.8
+`);
+    process.exit(0);
+  }
+
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+
+  if (subcommand === 'setup') {
+    await handleVectorSetupCommand(subArgs);
+  } else if (subcommand === 'setup-generic') {
+    await handleVectorSetupGenericCommand(subArgs);
+  } else if (subcommand === 'search') {
+    await handleVectorSearchCommand(subArgs);
+  } else {
+    console.error(`Unknown vector subcommand: ${subcommand}`);
+    process.exit(1);
+  }
+}
+
+async function handleVectorSetupCommand(args: string[]) {
+  const { convertCardsToJsonl, convertFaqsToJsonl } = await import('../lib/vector/converter.js');
+  const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+  const fs = await import('fs/promises');
+
+  // オプション解析
+  let type = 'all';
+  let keepTmp = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--keep-tmp') {
+      keepTmp = true;
+    } else if (!arg.startsWith('--')) {
+      type = arg;
+    }
+  }
+
+  if (!['cards', 'faqs', 'all'].includes(type)) {
+    console.error(`Invalid type: ${type}. Must be one of: cards, faqs, all`);
+    process.exit(1);
+  }
+
+  // tmpファイルのパスを保持
+  const tmpFiles: string[] = [];
+
+  // SIGINT対応
+  let interrupted = false;
+  process.on('SIGINT', async () => {
+    console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
+    interrupted = true;
+
+    try {
+      await cleanupTempTables();
+      console.error('クリーンアップ完了。既存のデータは保持されています。');
+    } catch (e) {
+      console.error('クリーンアップ中にエラー:', e);
+    }
+
+    process.exit(130);
+  });
+
+  try {
+    // 一時ディレクトリ作成
+    const tmpDir = getTmpDir();
+    await fs.mkdir(tmpDir, { recursive: true });
+
+    if (type === 'all' || type === 'cards') {
+      if (interrupted) return;
+      console.error('\n=== Cards のインデックス構築 ===');
+
+      const cardsTsvPath = getTsvPath('cards-all.tsv');
+      const detailTsvPath = getTsvPath('detail-all.tsv');
+      const cardsJsonlPath = getTmpPath('cards_for_vectordb.jsonl');
+      tmpFiles.push(cardsJsonlPath);
+
+      console.error('TSVからJSONLに変換中...');
+      const cardsCount = await convertCardsToJsonl(cardsTsvPath, detailTsvPath, cardsJsonlPath);
+      console.error(`${cardsCount}件のカードを変換しました`);
+
+      console.error('Vector DBインデックスを構築中...');
+      await indexFromJsonl('cards', cardsJsonlPath);
+    }
+
+    if (type === 'all' || type === 'faqs') {
+      if (interrupted) return;
+      console.error('\n=== FAQs のインデックス構築 ===');
+
+      const faqsTsvPath = getTsvPath('faq-all.tsv');
+      const faqsJsonlPath = getTmpPath('faqs_for_vectordb.jsonl');
+      tmpFiles.push(faqsJsonlPath);
+
+      console.error('TSVからJSONLに変換中...');
+      const faqsCount = await convertFaqsToJsonl(faqsTsvPath, faqsJsonlPath);
+      console.error(`${faqsCount}件のFAQを変換しました`);
+
+      console.error('Vector DBインデックスを構築中...');
+      await indexFromJsonl('faqs', faqsJsonlPath);
+    }
+
+    console.error('\n全てのインデックス構築が完了しました');
+
+    // tmpファイルのクリーンアップ
+    if (!keepTmp && tmpFiles.length > 0) {
+      console.error('\n一時ファイルをクリーンアップ中...');
+      for (const tmpFile of tmpFiles) {
+        try {
+          await fs.unlink(tmpFile);
+          console.error(`削除: ${tmpFile}`);
+        } catch (e: any) {
+          if (e.code !== 'ENOENT') {
+            console.error(`警告: ${tmpFile} の削除に失敗しました:`, e.message);
+          }
+        }
+      }
+      console.error('クリーンアップ完了');
+    } else if (keepTmp) {
+      console.error('\n--keep-tmpオプションが指定されているため、一時ファイルを保持します');
+    }
+  } catch (error: any) {
+    console.error('インデックス構築中にエラーが発生しました:', error.message);
+    process.exit(1);
+  }
+}
+
+async function handleVectorSearchCommand(args: string[]) {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(`Usage: ygo_search vector search <query> [options]
+
+Vector検索を実行
+
+Arguments:
+  query                 検索クエリ
+
+Options:
+  --type TYPE           検索対象（cards/faqs/all/カスタムテーブル名, デフォルト: all）
+  --limit N             最大結果数（デフォルト: 10）
+  --threshold N         スコア閾値（0.0-1.0, 小さいほど厳密）
+  --distance TYPE       距離メトリック（cosine/l2/dot, デフォルト: cosine）
+  --format FORMAT       出力形式（json/csv/tsv/jsonl, デフォルト: json）
+
+Examples:
+  ygo_search vector search "墓地から特殊召喚"
+  ygo_search vector search "融合召喚" --type cards --limit 5
+  ygo_search vector search "カウンター罠" --threshold 0.7
+  ygo_search vector search "チェーンブロック" --format jsonl
+  ygo_search vector search "特殊召喚" --type test
+`);
+    process.exit(0);
+  }
+
+  const query = args[0];
+  if (!query) {
+    console.error('Error: クエリを指定してください');
+    process.exit(1);
+  }
+
+  const { searchCards, searchFaqs, searchAll, searchTable } = await import('../lib/vector/searcher.js');
+  type SearchResult = Awaited<ReturnType<typeof searchTable>>[0];
+
+  // オプション解析
+  let type = 'all';
+  let limit = 10;
+  let threshold: number | undefined = undefined;
+  let distanceType: 'cosine' | 'l2' | 'dot' = 'cosine';
+  let format = 'json';
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--type' && i + 1 < args.length) {
+      type = args[++i];
+    } else if (args[i] === '--limit' && i + 1 < args.length) {
+      limit = parseInt(args[++i], 10);
+    } else if (args[i] === '--threshold' && i + 1 < args.length) {
+      threshold = parseFloat(args[++i]);
+    } else if (args[i] === '--distance' && i + 1 < args.length) {
+      distanceType = args[++i] as 'cosine' | 'l2' | 'dot';
+    } else if (args[i] === '--format' && i + 1 < args.length) {
+      format = args[++i];
+    }
+  }
+
+  const options = { limit, threshold, distanceType };
+
+  try {
+    console.error(`検索中: "${query}"\n`);
+
+    let results: any;
+
+    if (type === 'cards') {
+      const cards = await searchCards(query, options);
+      results = { cards };
+    } else if (type === 'faqs') {
+      const faqs = await searchFaqs(query, options);
+      results = { faqs };
+    } else if (type === 'all') {
+      results = await searchAll(query, options);
+    } else {
+      // カスタムテーブルの検索
+      const customResults = await searchTable(type, query, options);
+      results = { [type]: customResults };
+    }
+
+    // フォーマット出力
+    if (format === 'json') {
+      console.log(JSON.stringify(results, null, 2));
+    } else if (format === 'jsonl') {
+      // 全ての結果を配列に集める
+      const allResults = Object.values(results).flat() as SearchResult[];
+      for (const r of allResults) {
+        console.log(JSON.stringify(r));
+      }
+    } else if (format === 'csv' || format === 'tsv') {
+      const sep = format === 'csv' ? ',' : '\t';
+      // 全ての結果を配列に集める
+      const allResults = Object.values(results).flat() as SearchResult[];
+
+      if (allResults.length > 0) {
+        console.log(['id', 'score', 'text_preview'].join(sep));
+        for (const r of allResults) {
+          const textPreview = r.text.substring(0, 100).replace(/\n/g, ' ');
+          console.log([r.id, r.score.toFixed(4), `"${textPreview}..."`].join(sep));
+        }
+      }
+    }
+  } catch (error: any) {
+    console.error('検索エラー:', error.message);
+    process.exit(1);
+  }
+}
+
+async function handleVectorSetupGenericCommand(args: string[]) {
+  if (args.length < 2 || args[0] === '--help' || args[0] === '-h') {
+    console.log(`Usage: ygo_search vector setup-generic <inputFile> <tableName> [options]
+
+汎用データからVector DBインデックスを構築
+
+Arguments:
+  inputFile             入力ファイル（yaml/jsonl/json/tsv/csv）
+  tableName             テーブル名
+
+Options:
+  --exclude-columns col1,col2    指定カラムをテキストから除外
+  --include-columns col1,col2    指定カラムのみテキストに含める
+  --keep-tmp                     一時JSONLファイルを削除せずに保持
+
+Required fields: id, title, text
+
+Examples:
+  ygo_search vector setup-generic rules.yml rules
+  ygo_search vector setup-generic data.json custom --exclude-columns cite,sourceFile
+  ygo_search vector setup-generic items.tsv items --include-columns category,priority
+`);
+    process.exit(0);
+  }
+
+  const { convertGenericToJsonl } = await import('../lib/vector/converter.js');
+  const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+  const fs = await import('fs/promises');
+
+  const inputFile = args[0];
+  const tableName = args[1];
+
+  // オプション解析
+  let excludeColumns: string[] | undefined = undefined;
+  let includeColumns: string[] | undefined = undefined;
+  let keepTmp = false;
+
+  for (let i = 2; i < args.length; i++) {
+    if (args[i] === '--exclude-columns' && i + 1 < args.length) {
+      excludeColumns = args[++i].split(',').map(c => c.trim());
+    } else if (args[i] === '--include-columns' && i + 1 < args.length) {
+      includeColumns = args[++i].split(',').map(c => c.trim());
+    } else if (args[i] === '--keep-tmp') {
+      keepTmp = true;
+    }
+  }
+
+  // Validate exclusivity
+  if (excludeColumns && includeColumns) {
+    console.error('Error: Cannot specify both --exclude-columns and --include-columns');
+    process.exit(1);
+  }
+
+  const tmpFiles: string[] = [];
+
+  // SIGINT対応
+  let interrupted = false;
+  process.on('SIGINT', async () => {
+    console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
+    interrupted = true;
+
+    try {
+      await cleanupTempTables();
+      console.error('クリーンアップ完了。既存のデータは保持されています。');
+    } catch (e) {
+      console.error('クリーンアップ中にエラー:', e);
+    }
+
+    process.exit(130);
+  });
+
+  try {
+    // 一時ディレクトリ作成
+    const tmpDir = getTmpDir();
+    await fs.mkdir(tmpDir, { recursive: true });
+
+    console.error(`\n=== ${tableName} のインデックス構築 ===`);
+
+    const jsonlPath = getTmpPath(`${tableName}_for_vectordb.jsonl`);
+    tmpFiles.push(jsonlPath);
+
+    console.error(`${inputFile} からJSONLに変換中...`);
+    const options = excludeColumns ? { excludeColumns } : includeColumns ? { includeColumns } : undefined;
+    const count = await convertGenericToJsonl(inputFile, jsonlPath, options);
+    console.error(`${count}件のレコードを変換しました`);
+
+    console.error('Vector DBインデックスを構築中...');
+    await indexFromJsonl(tableName, jsonlPath);
+
+    console.error('\nインデックス構築が完了しました');
+
+    // tmpファイルのクリーンアップ
+    if (!keepTmp && tmpFiles.length > 0) {
+      console.error('\n一時ファイルをクリーンアップ中...');
+      for (const tmpFile of tmpFiles) {
+        try {
+          await fs.unlink(tmpFile);
+          console.error(`削除: ${tmpFile}`);
+        } catch (e: any) {
+          if (e.code !== 'ENOENT') {
+            console.error(`警告: ${tmpFile} の削除に失敗しました:`, e.message);
+          }
+        }
+      }
+      console.error('クリーンアップ完了');
+    } else if (keepTmp) {
+      console.error('\n--keep-tmpオプションが指定されているため、一時ファイルを保持します');
+    }
+  } catch (error: any) {
+    console.error('インデックス構築中にエラーが発生しました:', error.message);
+    process.exit(1);
+  }
+}
+
 // update サブコマンド（旧 ygo_update_search）
 function handleUpdateCommand() {
   const scriptPath = path.join(__dirname, 'ygo_update_search.js');
@@ -568,6 +943,9 @@ async function main() {
       break;
     case 'convert':
       handleConvertCommand(commandArgs);
+      break;
+    case 'vector':
+      await handleVectorCommand(commandArgs);
       break;
     case 'update':
       handleUpdateCommand();

--- a/src/cli/ygo_search.ts
+++ b/src/cli/ygo_search.ts
@@ -11,6 +11,24 @@ import { getTsvPath, getTmpPath, getTmpDir } from '../lib/config/paths.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
+// SIGINT ハンドラをセットアップする共通ヘルパー
+function setupInterruptHandler(): { interrupted: boolean; setInterrupted: (value: boolean) => void } {
+  const state = { interrupted: false };
+  process.on('SIGINT', async () => {
+    console.error('\n\n中断を検出しました。処理を終了します...');
+    state.interrupted = true;
+    process.exit(130);
+  });
+  return {
+    get interrupted() {
+      return state.interrupted;
+    },
+    setInterrupted(value: boolean) {
+      state.interrupted = value;
+    }
+  };
+}
+
 // カラム定義（旧 ygo_search.ts から）
 const COLUMN_DEFINITIONS = {
   // Basic information
@@ -576,7 +594,7 @@ Examples:
 
 async function handleVectorSetupCommand(args: string[]) {
   const { convertCardsToJsonl, convertFaqsToJsonl } = await import('../lib/vector/converter.js');
-  const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+  const { indexFromJsonl } = await import('../lib/vector/indexer.js');
   const fs = await import('fs/promises');
 
   // オプション解析
@@ -601,20 +619,7 @@ async function handleVectorSetupCommand(args: string[]) {
   const tmpFiles: string[] = [];
 
   // SIGINT対応
-  let interrupted = false;
-  process.on('SIGINT', async () => {
-    console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
-    interrupted = true;
-
-    try {
-      await cleanupTempTables();
-      console.error('クリーンアップ完了。既存のデータは保持されています。');
-    } catch (e) {
-      console.error('クリーンアップ中にエラー:', e);
-    }
-
-    process.exit(130);
-  });
+  const { interrupted } = setupInterruptHandler();
 
   try {
     // 一時ディレクトリ作成
@@ -773,7 +778,7 @@ Examples:
       if (allResults.length > 0) {
         console.log(['id', 'score', 'text_preview'].join(sep));
         for (const r of allResults) {
-          const textPreview = r.text.substring(0, 100).replace(/\n/g, ' ');
+          const textPreview = r.text.substring(0, 100).replace(/\n/g, ' ').replace(/"/g, '""');
           console.log([r.id, r.score.toFixed(4), `"${textPreview}..."`].join(sep));
         }
       }
@@ -810,7 +815,7 @@ Examples:
   }
 
   const { convertGenericToJsonl } = await import('../lib/vector/converter.js');
-  const { indexFromJsonl, cleanupTempTables } = await import('../lib/vector/indexer.js');
+  const { indexFromJsonl } = await import('../lib/vector/indexer.js');
   const fs = await import('fs/promises');
 
   const inputFile = args[0];
@@ -840,20 +845,7 @@ Examples:
   const tmpFiles: string[] = [];
 
   // SIGINT対応
-  let interrupted = false;
-  process.on('SIGINT', async () => {
-    console.error('\n\n中断を検出しました。一時テーブルをクリーンアップ中...');
-    interrupted = true;
-
-    try {
-      await cleanupTempTables();
-      console.error('クリーンアップ完了。既存のデータは保持されています。');
-    } catch (e) {
-      console.error('クリーンアップ中にエラー:', e);
-    }
-
-    process.exit(130);
-  });
+  const { interrupted } = setupInterruptHandler();
 
   try {
     // 一時ディレクトリ作成

--- a/src/cli/ygo_update_search.ts
+++ b/src/cli/ygo_update_search.ts
@@ -5,7 +5,7 @@ import fs from 'fs'
 import path from 'path'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { findProjectRoot } from '../utils/project-root.js'
+import { getTsvPath, getDataDir } from '../lib/config/paths.js'
 
 const execAsync = promisify(exec)
 
@@ -234,9 +234,8 @@ async function main() {
     console.log('YuGiOh-Scraping リポジトリからカードデータをダウンロードします...')
     console.log('')
 
-    // プロジェクトルートと data ディレクトリを確認
-    const projectRoot = await findProjectRoot()
-    const dataDir = path.join(projectRoot, 'data')
+    // TSVファイル保存先ディレクトリ
+    const dataDir = path.join(getDataDir(), 'tsv')
 
     if (!fs.existsSync(dataDir)) {
       await fs.promises.mkdir(dataDir, { recursive: true })
@@ -319,7 +318,8 @@ async function main() {
       }
       console.log('')
       console.log('以下のコマンドで検索できます:')
-      console.log('  ygo_search \'{"name":"青眼"}\'')
+      console.log('  ygo_search \'{"name":"*青眼*"}\'  # ワイルドカード検索')
+      console.log('  ygo_search \'{"name":"青眼の白龍"}\'  # 完全一致')
       console.log('')
 
     } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,6 +186,86 @@ export {
 export type { Format } from './lib/format-converter.js'
 
 // ============================================================================
+// Vector search
+// ============================================================================
+
+/**
+ * Vector検索機能
+ * @example
+ * ```ts
+ * import { vectorSearchCards, vectorSearchFaqs, vectorSearchAll, searchTable, listTables } from 'ygo-search'
+ *
+ * // カード検索
+ * const cardResults = await vectorSearchCards('墓地から特殊召喚', { limit: 5 })
+ *
+ * // FAQ検索
+ * const faqResults = await vectorSearchFaqs('チェーンブロック', { limit: 5 })
+ *
+ * // 全体検索（全テーブル）
+ * const allResults = await vectorSearchAll('融合召喚', { limit: 10 })
+ * // { cards: [...], faqs: [...], rules: [...], ... }
+ *
+ * // カスタムテーブル検索
+ * const customResults = await searchTable('rules', 'ターン', { limit: 5 })
+ *
+ * // テーブル一覧取得
+ * const tables = await listTables()
+ * ```
+ */
+export {
+  searchCards as vectorSearchCards,
+  searchFaqs as vectorSearchFaqs,
+  searchAll as vectorSearchAll,
+  searchTable,
+  listTables
+} from './lib/vector/searcher.js'
+
+export type {
+  SearchResult as VectorSearchResult,
+  VectorSearchOptions,
+  CardSearchOptions as VectorCardSearchOptions,
+  FaqSearchOptions as VectorFaqSearchOptions
+} from './lib/vector/searcher.js'
+
+// ============================================================================
+// Vector DB setup and conversion
+// ============================================================================
+
+/**
+ * Vector DBインデックス構築とデータ変換機能
+ * @example
+ * ```ts
+ * import { convertCardsToJsonl, convertFaqsToJsonl, convertGenericToJsonl, indexFromJsonl } from 'ygo-search'
+ *
+ * // カードデータをJSONLに変換
+ * const count = await convertCardsToJsonl('cards.tsv', 'detail.tsv', 'cards.jsonl')
+ *
+ * // FAQデータをJSONLに変換
+ * const faqCount = await convertFaqsToJsonl('faqs.tsv', 'faqs.jsonl')
+ *
+ * // 汎用データをJSONLに変換
+ * const genericCount = await convertGenericToJsonl('data.json', 'output.jsonl', {
+ *   excludeColumns: ['cite', 'sourceFile']
+ * })
+ *
+ * // Vector DBインデックスを構築
+ * await indexFromJsonl('cards', 'cards.jsonl')
+ * ```
+ */
+export {
+  convertCardsToJsonl,
+  convertFaqsToJsonl,
+  convertGenericToJsonl
+} from './lib/vector/converter.js'
+
+export type {
+  VectorRecord,
+  GenericConversionOptions
+} from './lib/vector/converter.js'
+
+export { indexFromJsonl } from './lib/vector/indexer.js'
+
+// ============================================================================
 // Utilities
 // ============================================================================
 

--- a/src/lib/card-search-core.ts
+++ b/src/lib/card-search-core.ts
@@ -6,7 +6,7 @@
 import fs from 'fs'
 import path from 'path'
 import readline from 'readline'
-import { findProjectRoot } from '../utils/project-root.js'
+import { getTsvPath } from './config/paths.js'
 import { Card } from '../types/card.js'
 
 export interface CardSearchParams {
@@ -126,9 +126,7 @@ export async function searchCards(params: CardSearchParams): Promise<Card[]> {
     }
   }
 
-  const projectRoot = await findProjectRoot()
-  const dataDir = path.join(projectRoot, 'data')
-  const cardsFile = path.join(dataDir, 'cards-all.tsv')
+  const cardsFile = getTsvPath('cards-all.tsv')
 
   if (!fs.existsSync(cardsFile)) {
     throw new Error(`カードデータファイルが見つかりません: ${cardsFile}\n\n以下のコマンドでデータをダウンロードしてください:\n  ygo_update_search`)

--- a/src/lib/config/paths.ts
+++ b/src/lib/config/paths.ts
@@ -1,0 +1,63 @@
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * ホームディレクトリを展開する
+ */
+function expandHome(filepath: string): string {
+  if (filepath.startsWith('~/') || filepath === '~') {
+    return path.join(os.homedir(), filepath.slice(1));
+  }
+  return filepath;
+}
+
+/**
+ * ワークディレクトリを取得
+ * 環境変数YGO_SEARCH_WORKDIRが設定されていればそれを使用
+ * 未設定の場合はデフォルト: ~/.local/ygo-search/
+ */
+export function getWorkDir(): string {
+  const envWorkDir = process.env.YGO_SEARCH_WORKDIR;
+
+  if (envWorkDir) {
+    return expandHome(envWorkDir);
+  }
+
+  // デフォルト: ~/.local/ygo-search/
+  return path.join(os.homedir(), '.local', 'ygo-search');
+}
+
+/**
+ * TSVファイルのパスを取得
+ */
+export function getTsvPath(filename: string): string {
+  return path.join(getWorkDir(), 'data', 'tsv', filename);
+}
+
+/**
+ * Vector DBディレクトリのパスを取得
+ */
+export function getVectorDbPath(): string {
+  return path.join(getWorkDir(), 'data', 'vector');
+}
+
+/**
+ * tmpファイルのパスを取得
+ */
+export function getTmpPath(filename: string): string {
+  return path.join(getWorkDir(), 'tmp', filename);
+}
+
+/**
+ * tmpディレクトリのパスを取得
+ */
+export function getTmpDir(): string {
+  return path.join(getWorkDir(), 'tmp');
+}
+
+/**
+ * データディレクトリのパスを取得
+ */
+export function getDataDir(): string {
+  return path.join(getWorkDir(), 'data');
+}

--- a/src/lib/vector/converter.ts
+++ b/src/lib/vector/converter.ts
@@ -1,0 +1,474 @@
+import * as fs from 'fs/promises';
+
+export interface VectorRecord {
+  id: string;
+  text: string;
+  metadata: Record<string, any>;
+}
+
+interface CardRow {
+  cardType: string;
+  name: string;
+  nameModified: string;
+  ruby: string;
+  cardId: string;
+  ciid: string;
+  imgs: string;
+  text: string;
+  biko: string;
+  isNotLegalForOfficial: string;
+  attribute: string;
+  levelType: string;
+  levelValue: string;
+  race: string;
+  monsterTypes: string;
+  atk: string;
+  def: string;
+  linkMarkers: string;
+  pendulumScale: string;
+  pendulumText: string;
+  isExtraDeck: string;
+  spellEffectType: string;
+  trapEffectType: string;
+}
+
+interface DetailRow {
+  cardId: string;
+  cardName: string;
+  supplementInfo: string;
+  supplementDate: string;
+  pendulumSupplementInfo: string;
+  pendulumSupplementDate: string;
+}
+
+interface FaqRow {
+  faqId: string;
+  question: string;
+  answer: string;
+  updatedAt: string;
+}
+
+function parseTsvLine(line: string, headers: string[]): Record<string, string> {
+  const values = line.split('\t');
+  const record: Record<string, string> = {};
+  headers.forEach((header, index) => {
+    record[header] = values[index] || '';
+  });
+  return record;
+}
+
+function formatCardType(cardType: string, monsterTypes: string, spellEffectType: string, trapEffectType: string): string {
+  if (cardType === 'monster') {
+    try {
+      const types = JSON.parse(monsterTypes);
+      if (Array.isArray(types) && types.length > 0) {
+        return types.map((t: string) => {
+          const typeMap: Record<string, string> = {
+            'normal': '通常',
+            'effect': '効果',
+            'fusion': '融合',
+            'ritual': '儀式',
+            'synchro': 'シンクロ',
+            'xyz': 'エクシーズ',
+            'pendulum': 'ペンデュラム',
+            'link': 'リンク',
+            'tuner': 'チューナー',
+            'spirit': 'スピリット',
+            'union': 'ユニオン',
+            'gemini': 'デュアル',
+            'flip': 'リバース',
+            'toon': 'トゥーン'
+          };
+          return typeMap[t] || t;
+        }).join('・') + 'モンスター';
+      }
+    } catch (e) {
+      // JSON parse failed
+    }
+    return 'モンスター';
+  } else if (cardType === 'spell') {
+    const typeMap: Record<string, string> = {
+      'normal': '通常',
+      'continuous': '永続',
+      'equip': '装備',
+      'field': 'フィールド',
+      'quickPlay': '速攻',
+      'ritual': '儀式'
+    };
+    return (typeMap[spellEffectType] || '') + '魔法';
+  } else if (cardType === 'trap') {
+    const typeMap: Record<string, string> = {
+      'normal': '通常',
+      'continuous': '永続',
+      'counter': 'カウンター'
+    };
+    return (typeMap[trapEffectType] || '') + '罠';
+  }
+  return cardType;
+}
+
+function formatMonsterStatus(card: CardRow): string {
+  const parts: string[] = [];
+
+  if (card.attribute) {
+    parts.push(card.attribute);
+  }
+
+  if (card.race) {
+    parts.push(card.race);
+  }
+
+  if (card.levelType && card.levelValue) {
+    const levelTypeMap: Record<string, string> = {
+      'level': '星',
+      'rank': 'ランク',
+      'link': 'リンク'
+    };
+    const prefix = levelTypeMap[card.levelType] || card.levelType;
+    parts.push(`${prefix}${card.levelValue}`);
+  }
+
+  if (card.atk !== '' && card.def !== '') {
+    parts.push(`攻${card.atk}`);
+    parts.push(`守${card.def}`);
+  }
+
+  return parts.join(' / ');
+}
+
+export function convertCardToVectorRecord(card: CardRow, detail?: DetailRow): VectorRecord {
+  const textParts: string[] = [];
+
+  textParts.push(`【カード名】 ${card.name}`);
+
+  const cardTypeStr = formatCardType(card.cardType, card.monsterTypes, card.spellEffectType, card.trapEffectType);
+  textParts.push(`【分類】 ${cardTypeStr}`);
+
+  if (card.cardType === 'monster') {
+    const status = formatMonsterStatus(card);
+    if (status) {
+      textParts.push(`【ステータス】 ${status}`);
+    }
+  }
+
+  if (card.text) {
+    textParts.push(`【テキスト】\n${card.text}`);
+  }
+
+  if (card.pendulumText && card.pendulumText !== 'false') {
+    textParts.push(`【Pスケール効果】\n${card.pendulumText}`);
+  }
+
+  if (detail?.supplementInfo) {
+    textParts.push(`【補足】\n${detail.supplementInfo}`);
+  }
+
+  if (detail?.pendulumSupplementInfo) {
+    textParts.push(`【Pスケール補足】\n${detail.pendulumSupplementInfo}`);
+  }
+
+  const metadata: Record<string, any> = {
+    cardId: parseInt(card.cardId, 10),
+    cardType: card.cardType,
+  };
+
+  if (card.cardType === 'monster') {
+    if (card.atk !== '') metadata.atk = parseInt(card.atk, 10);
+    if (card.def !== '') metadata.def = parseInt(card.def, 10);
+    if (card.attribute) metadata.attribute = card.attribute;
+    if (card.race) metadata.race = card.race;
+    if (card.levelType) metadata.levelType = card.levelType;
+    if (card.levelValue) metadata.levelValue = parseInt(card.levelValue, 10);
+  } else if (card.cardType === 'spell' && card.spellEffectType) {
+    metadata.spellEffectType = card.spellEffectType;
+  } else if (card.cardType === 'trap' && card.trapEffectType) {
+    metadata.trapEffectType = card.trapEffectType;
+  }
+
+  return {
+    id: `card-${card.cardId}`,
+    text: textParts.join('\n'),
+    metadata,
+  };
+}
+
+export function convertFaqToVectorRecord(faq: FaqRow): VectorRecord {
+  const textParts: string[] = [];
+
+  textParts.push(`# 質問\n${faq.question}`);
+  textParts.push(`\n# 回答\n${faq.answer}`);
+
+  const metadata: Record<string, any> = {
+    faqId: parseInt(faq.faqId, 10),
+  };
+
+  if (faq.updatedAt) {
+    metadata.updatedAt = faq.updatedAt;
+  }
+
+  return {
+    id: `faq-${faq.faqId}`,
+    text: textParts.join('\n'),
+    metadata,
+  };
+}
+
+export async function convertCardsToJsonl(
+  cardsTsvPath: string,
+  detailTsvPath: string,
+  outputPath: string
+): Promise<number> {
+  const cardsContent = await fs.readFile(cardsTsvPath, 'utf-8');
+  const cardsLines = cardsContent.trim().split('\n');
+
+  if (cardsLines.length === 0) {
+    throw new Error('Cards TSV file is empty');
+  }
+
+  const cardsHeaders = cardsLines[0].split('\t');
+  const cardsMap = new Map<string, CardRow>();
+
+  for (let i = 1; i < cardsLines.length; i++) {
+    const row = parseTsvLine(cardsLines[i], cardsHeaders) as unknown as CardRow;
+    cardsMap.set(row.cardId, row);
+  }
+
+  const detailContent = await fs.readFile(detailTsvPath, 'utf-8');
+  const detailLines = detailContent.trim().split('\n');
+
+  const detailHeaders = detailLines[0].split('\t');
+  const detailMap = new Map<string, DetailRow>();
+
+  for (let i = 1; i < detailLines.length; i++) {
+    const row = parseTsvLine(detailLines[i], detailHeaders) as unknown as DetailRow;
+    detailMap.set(row.cardId, row);
+  }
+
+  const records: VectorRecord[] = [];
+
+  for (const [cardId, card] of cardsMap) {
+    const detail = detailMap.get(cardId);
+    const record = convertCardToVectorRecord(card, detail);
+    records.push(record);
+  }
+
+  const jsonlLines = records.map(r => JSON.stringify(r));
+  await fs.writeFile(outputPath, jsonlLines.join('\n') + '\n', 'utf-8');
+
+  return records.length;
+}
+
+export async function convertFaqsToJsonl(
+  tsvPath: string,
+  outputPath: string
+): Promise<number> {
+  const content = await fs.readFile(tsvPath, 'utf-8');
+  const lines = content.trim().split('\n');
+
+  if (lines.length === 0) {
+    throw new Error('TSV file is empty');
+  }
+
+  const headers = lines[0].split('\t');
+  const records: VectorRecord[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const row = parseTsvLine(lines[i], headers) as unknown as FaqRow;
+    const record = convertFaqToVectorRecord(row);
+    records.push(record);
+  }
+
+  const jsonlLines = records.map(r => JSON.stringify(r));
+  await fs.writeFile(outputPath, jsonlLines.join('\n') + '\n', 'utf-8');
+
+  return records.length;
+}
+
+// Generic data conversion
+
+interface GenericRecord {
+  id: string;
+  title: string;
+  text: string;
+  [key: string]: any;
+}
+
+export interface GenericConversionOptions {
+  excludeColumns?: string[];
+  includeColumns?: string[];
+}
+
+function detectFormat(filePath: string): 'yaml' | 'jsonl' | 'json' | 'tsv' | 'csv' {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  if (ext === 'yml' || ext === 'yaml') return 'yaml';
+  if (ext === 'jsonl') return 'jsonl';
+  if (ext === 'json') return 'json';
+  if (ext === 'tsv') return 'tsv';
+  if (ext === 'csv') return 'csv';
+  throw new Error(`Unsupported file format: ${ext}`);
+}
+
+function extractRecordsFromObject(obj: any, records: GenericRecord[] = [], path: string[] = []): GenericRecord[] {
+  if (typeof obj !== 'object' || obj === null) {
+    return records;
+  }
+
+  // Check if this object has id, title, text
+  if ('id' in obj && 'title' in obj && 'text' in obj) {
+    const record = { ...obj } as GenericRecord;
+    // 階層パスを追加（ルート以外の場合）
+    if (path.length > 0) {
+      record.path = path.join(' > ');
+    }
+    records.push(record);
+  }
+
+  // Recursively search in arrays and objects
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      extractRecordsFromObject(item, records, path);
+    }
+  } else {
+    for (const [key, value] of Object.entries(obj)) {
+      extractRecordsFromObject(value, records, [...path, key]);
+    }
+  }
+
+  return records;
+}
+
+function buildGenericText(record: GenericRecord, options?: GenericConversionOptions): string {
+  const textParts: string[] = [];
+
+  // Always include title
+  textParts.push(`【${record.title}】`);
+
+  // Include path if exists (before text)
+  if ('path' in record && record.path) {
+    textParts.push(`【階層】\n${record.path}`);
+  }
+
+  // Always include text
+  textParts.push(`【テキスト】\n${record.text}`);
+
+  // Determine which columns to include
+  const excludeCols = new Set(options?.excludeColumns || []);
+  const includeCols = options?.includeColumns ? new Set(options.includeColumns) : null;
+
+  // Validate exclusivity
+  if (excludeCols.size > 0 && includeCols !== null) {
+    throw new Error('Cannot specify both excludeColumns and includeColumns');
+  }
+
+  // Add other fields
+  for (const [key, value] of Object.entries(record)) {
+    // Skip id, title, text, path (already handled)
+    if (key === 'id' || key === 'title' || key === 'text' || key === 'path') continue;
+
+    // Apply column filtering
+    if (includeCols !== null) {
+      if (!includeCols.has(key)) continue;
+    } else if (excludeCols.has(key)) {
+      continue;
+    }
+
+    // Format value
+    let valueStr: string;
+    if (typeof value === 'object') {
+      valueStr = JSON.stringify(value);
+    } else {
+      valueStr = String(value);
+    }
+
+    textParts.push(`【${key}】\n${valueStr}`);
+  }
+
+  return textParts.join('\n');
+}
+
+function convertGenericRecordToVector(record: GenericRecord, options?: GenericConversionOptions): VectorRecord {
+  const text = buildGenericText(record, options);
+
+  const metadata: Record<string, any> = { ...record };
+  delete metadata.title;
+  delete metadata.text;
+  delete metadata.path;
+
+  return {
+    id: record.id,
+    text,
+    metadata,
+  };
+}
+
+export async function convertGenericToJsonl(
+  inputPath: string,
+  outputPath: string,
+  options?: GenericConversionOptions
+): Promise<number> {
+  const format = detectFormat(inputPath);
+  const content = await fs.readFile(inputPath, 'utf-8');
+
+  let records: GenericRecord[] = [];
+
+  if (format === 'yaml') {
+    const yaml = await import('js-yaml');
+    const data = yaml.load(content);
+    records = extractRecordsFromObject(data);
+  } else if (format === 'jsonl') {
+    const lines = content.trim().split('\n');
+    for (const line of lines) {
+      if (!line) continue;
+      const obj = JSON.parse(line);
+      const extracted = extractRecordsFromObject(obj);
+      records.push(...extracted);
+    }
+  } else if (format === 'json') {
+    const data = JSON.parse(content);
+    records = extractRecordsFromObject(data);
+  } else if (format === 'tsv') {
+    const lines = content.trim().split('\n');
+    if (lines.length === 0) throw new Error('TSV file is empty');
+
+    const headers = lines[0].split('\t');
+    if (!headers.includes('id') || !headers.includes('title') || !headers.includes('text')) {
+      throw new Error('TSV must have id, title, text columns');
+    }
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = lines[i].split('\t');
+      const record: any = {};
+      headers.forEach((header, index) => {
+        record[header] = values[index] || '';
+      });
+      records.push(record as GenericRecord);
+    }
+  } else if (format === 'csv') {
+    const lines = content.trim().split('\n');
+    if (lines.length === 0) throw new Error('CSV file is empty');
+
+    // Simple CSV parser (does not handle quoted commas)
+    const headers = lines[0].split(',').map(h => h.trim());
+    if (!headers.includes('id') || !headers.includes('title') || !headers.includes('text')) {
+      throw new Error('CSV must have id, title, text columns');
+    }
+
+    for (let i = 1; i < lines.length; i++) {
+      const values = lines[i].split(',').map(v => v.trim());
+      const record: any = {};
+      headers.forEach((header, index) => {
+        record[header] = values[index] || '';
+      });
+      records.push(record as GenericRecord);
+    }
+  }
+
+  // Convert to vector records
+  const vectorRecords = records.map(r => convertGenericRecordToVector(r, options));
+
+  // Write JSONL
+  const jsonlLines = vectorRecords.map(r => JSON.stringify(r));
+  await fs.writeFile(outputPath, jsonlLines.join('\n') + '\n', 'utf-8');
+
+  return vectorRecords.length;
+}

--- a/src/lib/vector/embeddings.ts
+++ b/src/lib/vector/embeddings.ts
@@ -1,0 +1,40 @@
+import { pipeline, type FeatureExtractionPipeline } from '@xenova/transformers';
+
+let embeddingPipeline: FeatureExtractionPipeline | null = null;
+
+export async function initEmbeddings(): Promise<FeatureExtractionPipeline> {
+  if (!embeddingPipeline) {
+    console.error('Embedding modelを初期化中 (multilingual-e5-small)...');
+    embeddingPipeline = await pipeline(
+      'feature-extraction',
+      'Xenova/multilingual-e5-small'
+    );
+    console.error('Embedding modelの読み込み完了');
+  }
+  return embeddingPipeline;
+}
+
+export async function generateEmbedding(text: string): Promise<number[]> {
+  const model = await initEmbeddings();
+  const output = await model(text, { pooling: 'mean', normalize: true });
+  return Array.from(output.data);
+}
+
+export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
+  const model = await initEmbeddings();
+  const embeddings: number[][] = [];
+
+  const BATCH_SIZE = 32;
+  for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+    const batch = texts.slice(i, Math.min(i + BATCH_SIZE, texts.length));
+    console.error(`Embeddingを生成中: ${i}/${texts.length}`);
+
+    const batchPromises = batch.map(text =>
+      model(text, { pooling: 'mean', normalize: true })
+    );
+    const batchResults = await Promise.all(batchPromises);
+    embeddings.push(...batchResults.map(output => Array.from(output.data)));
+  }
+
+  return embeddings;
+}

--- a/src/lib/vector/embeddings.ts
+++ b/src/lib/vector/embeddings.ts
@@ -27,13 +27,17 @@ export async function generateEmbeddings(texts: string[]): Promise<number[][]> {
   const BATCH_SIZE = 32;
   for (let i = 0; i < texts.length; i += BATCH_SIZE) {
     const batch = texts.slice(i, Math.min(i + BATCH_SIZE, texts.length));
-    console.error(`Embeddingを生成中: ${i}/${texts.length}`);
+    console.error(`Embeddingを生成中: ${i + batch.length}/${texts.length}`);
 
-    const batchPromises = batch.map(text =>
-      model(text, { pooling: 'mean', normalize: true })
-    );
-    const batchResults = await Promise.all(batchPromises);
-    embeddings.push(...batchResults.map(output => Array.from(output.data)));
+    // バッチ全体を一度にモデルに渡す
+    const output = await model(batch, { pooling: 'mean', normalize: true });
+
+    const [batchSize, embeddingDim] = output.dims;
+    for (let j = 0; j < batchSize; j++) {
+      const start = j * embeddingDim;
+      const end = start + embeddingDim;
+      embeddings.push(Array.from(output.data.slice(start, end)));
+    }
   }
 
   return embeddings;

--- a/src/lib/vector/indexer.ts
+++ b/src/lib/vector/indexer.ts
@@ -5,8 +5,6 @@ import { getVectorDbPath } from '../config/paths.js';
 
 const getDbPath = () => getVectorDbPath();
 
-const TEMP_PREFIX = '_tmp_';
-
 export interface VectorRecord {
   id: string;
   text: string;
@@ -18,22 +16,6 @@ export interface VectorRecordWithEmbedding {
   text: string;
   vector: number[];
   metadata: Record<string, any>;
-}
-
-export async function cleanupTempTables(): Promise<void> {
-  try {
-    const db = await lancedb.connect(getDbPath());
-    const tables = await db.tableNames();
-
-    for (const table of tables) {
-      if (table.startsWith(TEMP_PREFIX)) {
-        console.error(`一時テーブルを削除: ${table}`);
-        await db.dropTable(table);
-      }
-    }
-  } catch (e) {
-    // DBが存在しない場合は無視
-  }
 }
 
 export async function createIndex(
@@ -57,26 +39,17 @@ export async function createIndex(
   console.error('LanceDBに接続中...');
   const db = await lancedb.connect(getDbPath());
 
-  const tempTableName = `${TEMP_PREFIX}${tableName}`;
-
   const existingTables = await db.tableNames();
 
-  if (existingTables.includes(tempTableName)) {
-    console.error(`既存の一時テーブルを削除: ${tempTableName}`);
-    await db.dropTable(tempTableName);
-  }
-
-  console.error(`一時テーブルを作成: ${tempTableName}`);
-  await db.createTable(tempTableName, vectorRecords as any);
-
+  // 既存テーブルがあれば削除
   if (existingTables.includes(tableName)) {
     console.error(`既存テーブルを削除: ${tableName}`);
     await db.dropTable(tableName);
   }
 
-  console.error(`テーブルをリネーム: ${tempTableName} -> ${tableName}`);
+  // 新しいテーブルを作成（一時テーブルを使わずに直接作成）
+  console.error(`テーブルを作成: ${tableName}`);
   await db.createTable(tableName, vectorRecords as any);
-  await db.dropTable(tempTableName);
 
   console.error(`✓ インデックス作成完了: ${tableName} (${records.length}件)`);
 }

--- a/src/lib/vector/indexer.ts
+++ b/src/lib/vector/indexer.ts
@@ -1,0 +1,102 @@
+import * as lancedb from '@lancedb/lancedb';
+import * as fs from 'fs/promises';
+import { generateEmbeddings } from './embeddings.js';
+import { getVectorDbPath } from '../config/paths.js';
+
+const getDbPath = () => getVectorDbPath();
+
+const TEMP_PREFIX = '_tmp_';
+
+export interface VectorRecord {
+  id: string;
+  text: string;
+  metadata: Record<string, any>;
+}
+
+export interface VectorRecordWithEmbedding {
+  id: string;
+  text: string;
+  vector: number[];
+  metadata: Record<string, any>;
+}
+
+export async function cleanupTempTables(): Promise<void> {
+  try {
+    const db = await lancedb.connect(getDbPath());
+    const tables = await db.tableNames();
+
+    for (const table of tables) {
+      if (table.startsWith(TEMP_PREFIX)) {
+        console.error(`一時テーブルを削除: ${table}`);
+        await db.dropTable(table);
+      }
+    }
+  } catch (e) {
+    // DBが存在しない場合は無視
+  }
+}
+
+export async function createIndex(
+  tableName: string,
+  records: VectorRecord[]
+): Promise<void> {
+  console.error(`テーブルを作成中: ${tableName}`);
+  console.error(`レコード数: ${records.length}`);
+
+  const texts = records.map(r => r.text);
+  console.error('Embeddingを生成中...');
+  const vectors = await generateEmbeddings(texts);
+
+  const vectorRecords: VectorRecordWithEmbedding[] = records.map((r, i) => ({
+    id: r.id,
+    text: r.text,
+    vector: vectors[i],
+    metadata: r.metadata,
+  }));
+
+  console.error('LanceDBに接続中...');
+  const db = await lancedb.connect(getDbPath());
+
+  const tempTableName = `${TEMP_PREFIX}${tableName}`;
+
+  const existingTables = await db.tableNames();
+
+  if (existingTables.includes(tempTableName)) {
+    console.error(`既存の一時テーブルを削除: ${tempTableName}`);
+    await db.dropTable(tempTableName);
+  }
+
+  console.error(`一時テーブルを作成: ${tempTableName}`);
+  await db.createTable(tempTableName, vectorRecords as any);
+
+  if (existingTables.includes(tableName)) {
+    console.error(`既存テーブルを削除: ${tableName}`);
+    await db.dropTable(tableName);
+  }
+
+  console.error(`テーブルをリネーム: ${tempTableName} -> ${tableName}`);
+  await db.createTable(tableName, vectorRecords as any);
+  await db.dropTable(tempTableName);
+
+  console.error(`✓ インデックス作成完了: ${tableName} (${records.length}件)`);
+}
+
+export async function indexFromJsonl(
+  tableName: string,
+  jsonlPath: string
+): Promise<void> {
+  console.error(`JSONLファイルを読み込み中: ${jsonlPath}`);
+  const content = await fs.readFile(jsonlPath, 'utf-8');
+  const lines = content.trim().split('\n');
+
+  const records: VectorRecord[] = lines.map(line => {
+    const data = JSON.parse(line);
+    return {
+      id: data.id,
+      text: data.text,
+      metadata: data.metadata || {},
+    };
+  });
+
+  await createIndex(tableName, records);
+}

--- a/src/lib/vector/searcher.ts
+++ b/src/lib/vector/searcher.ts
@@ -85,7 +85,7 @@ function buildExcludeClause(
 
 export async function searchTable(
   tableName: string,
-  query: string,
+  query: string | number[],
   options: VectorSearchOptions = {}
 ): Promise<SearchResult[]> {
   const {
@@ -99,7 +99,10 @@ export async function searchTable(
   const db = await lancedb.connect(getDbPath());
   const table = await db.openTable(tableName);
 
-  const queryVector = await generateEmbedding(query);
+  // queryが文字列なら embedding を生成、配列ならそのまま使用
+  const queryVector = typeof query === 'string'
+    ? await generateEmbedding(query)
+    : query;
 
   let search = table
     .vectorSearch(queryVector)
@@ -193,18 +196,19 @@ export async function searchAll(
     options = { limit: options };
   }
 
-  // Embedding modelを事前に初期化
-  const { initEmbeddings } = await import('./embeddings.js');
+  // Embedding modelを事前に初期化し、embeddingを一度だけ生成
+  const { initEmbeddings, generateEmbedding } = await import('./embeddings.js');
   await initEmbeddings();
+  const queryVector = await generateEmbedding(query);
 
   // 全テーブルを取得
   const allTables = await listTables();
 
-  // 全テーブルに対して並列検索
+  // 全テーブルに対して並列検索（embeddingを再利用）
   const results = await Promise.all(
     allTables.map(async (tableName) => {
       try {
-        const tableResults = await searchTable(tableName, query, options as VectorSearchOptions);
+        const tableResults = await searchTable(tableName, queryVector, options as VectorSearchOptions);
         return { tableName, results: tableResults };
       } catch (error) {
         // テーブルが存在しないか、エラーが発生した場合はスキップ

--- a/src/lib/vector/searcher.ts
+++ b/src/lib/vector/searcher.ts
@@ -1,0 +1,226 @@
+import * as lancedb from '@lancedb/lancedb';
+import { generateEmbedding } from './embeddings.js';
+import { getVectorDbPath } from '../config/paths.js';
+
+const getDbPath = () => getVectorDbPath();
+
+export interface SearchResult {
+  id: string;
+  text: string;
+  metadata: Record<string, any>;
+  score: number;
+}
+
+export interface VectorSearchOptions {
+  limit?: number;
+  distanceType?: 'l2' | 'cosine' | 'dot';
+  threshold?: number;
+  filter?: Record<string, any>;
+  exclude?: {
+    ids?: string[];
+    faqIds?: string[];
+    categories?: string[];
+  };
+}
+
+export interface CardSearchOptions extends VectorSearchOptions {
+  cardType?: 'monster' | 'spell' | 'trap';
+  attribute?: string;
+  level?: { min?: number; max?: number };
+  race?: string;
+}
+
+export interface FaqSearchOptions extends VectorSearchOptions {
+  faqId?: string;
+}
+
+function buildWhereClause(filter: Record<string, any>): string | null {
+  const conditions: string[] = [];
+
+  for (const [key, value] of Object.entries(filter)) {
+    if (value === undefined || value === null) continue;
+
+    if (typeof value === 'string') {
+      conditions.push(`metadata.${key} = "${value}"`);
+    } else if (typeof value === 'number') {
+      conditions.push(`metadata.${key} = ${value}`);
+    } else if (typeof value === 'boolean') {
+      conditions.push(`metadata.${key} = ${value}`);
+    } else if (typeof value === 'object' && 'min' in value) {
+      if (value.min !== undefined) {
+        conditions.push(`metadata.${key} >= ${value.min}`);
+      }
+      if (value.max !== undefined) {
+        conditions.push(`metadata.${key} <= ${value.max}`);
+      }
+    }
+  }
+
+  return conditions.length > 0 ? conditions.join(' AND ') : null;
+}
+
+function buildExcludeClause(
+  exclude: NonNullable<VectorSearchOptions['exclude']>,
+  tableName: string
+): string | null {
+  const conditions: string[] = [];
+
+  if (exclude.ids && exclude.ids.length > 0) {
+    const idList = exclude.ids.map(id => `"${id}"`).join(', ');
+    conditions.push(`id NOT IN (${idList})`);
+  }
+
+  if (exclude.faqIds && exclude.faqIds.length > 0 && tableName === 'faqs') {
+    const faqIdList = exclude.faqIds.map(id => `${id}`).join(', ');
+    conditions.push(`metadata.faqId NOT IN (${faqIdList})`);
+  }
+
+  if (exclude.categories && exclude.categories.length > 0) {
+    const categoryList = exclude.categories.map(cat => `"${cat}"`).join(', ');
+    conditions.push(`metadata.category NOT IN (${categoryList})`);
+  }
+
+  return conditions.length > 0 ? conditions.join(' AND ') : null;
+}
+
+export async function searchTable(
+  tableName: string,
+  query: string,
+  options: VectorSearchOptions = {}
+): Promise<SearchResult[]> {
+  const {
+    limit = 10,
+    distanceType = 'cosine',
+    threshold,
+    filter,
+    exclude,
+  } = options;
+
+  const db = await lancedb.connect(getDbPath());
+  const table = await db.openTable(tableName);
+
+  const queryVector = await generateEmbedding(query);
+
+  let search = table
+    .vectorSearch(queryVector)
+    .distanceType(distanceType)
+    .limit(limit);
+
+  const whereClauses: string[] = [];
+
+  if (filter) {
+    const filterClause = buildWhereClause(filter);
+    if (filterClause) whereClauses.push(filterClause);
+  }
+
+  if (exclude) {
+    const excludeClause = buildExcludeClause(exclude, tableName);
+    if (excludeClause) whereClauses.push(excludeClause);
+  }
+
+  if (whereClauses.length > 0) {
+    search = search.where(whereClauses.join(' AND '));
+  }
+
+  const results = await search.toArray();
+
+  let filtered = results.map((r: any) => ({
+    id: r.id,
+    text: r.text,
+    metadata: r.metadata,
+    score: r._distance,
+  }));
+
+  if (threshold !== undefined) {
+    filtered = filtered.filter(r => r.score <= threshold);
+  }
+
+  return filtered;
+}
+
+export async function searchCards(
+  query: string,
+  options: number | CardSearchOptions = {}
+): Promise<SearchResult[]> {
+  if (typeof options === 'number') {
+    options = { limit: options };
+  }
+
+  const { cardType, attribute, level, race, ...baseOptions } = options;
+
+  const filter: Record<string, any> = {};
+  if (cardType) filter.cardType = cardType;
+  if (attribute) filter.attribute = attribute;
+  if (race) filter.race = race;
+  if (level) filter.level = level;
+
+  return searchTable('cards', query, {
+    ...baseOptions,
+    filter: Object.keys(filter).length > 0 ? filter : undefined,
+  });
+}
+
+export async function searchFaqs(
+  query: string,
+  options: number | FaqSearchOptions = {}
+): Promise<SearchResult[]> {
+  if (typeof options === 'number') {
+    options = { limit: options };
+  }
+
+  const { faqId, ...baseOptions } = options;
+
+  const filter: Record<string, any> = {};
+  if (faqId) filter.faqId = faqId;
+
+  return searchTable('faqs', query, {
+    ...baseOptions,
+    filter: Object.keys(filter).length > 0 ? filter : undefined,
+  });
+}
+
+export async function listTables(): Promise<string[]> {
+  const db = await lancedb.connect(getDbPath());
+  const tableNames = await db.tableNames();
+  return tableNames;
+}
+
+export async function searchAll(
+  query: string,
+  options: number | VectorSearchOptions = {}
+): Promise<Record<string, SearchResult[]>> {
+  if (typeof options === 'number') {
+    options = { limit: options };
+  }
+
+  // Embedding modelを事前に初期化
+  const { initEmbeddings } = await import('./embeddings.js');
+  await initEmbeddings();
+
+  // 全テーブルを取得
+  const allTables = await listTables();
+
+  // 全テーブルに対して並列検索
+  const results = await Promise.all(
+    allTables.map(async (tableName) => {
+      try {
+        const tableResults = await searchTable(tableName, query, options as VectorSearchOptions);
+        return { tableName, results: tableResults };
+      } catch (error) {
+        // テーブルが存在しないか、エラーが発生した場合はスキップ
+        console.error(`Warning: Failed to search table ${tableName}:`, (error as Error).message);
+        return { tableName, results: [] };
+      }
+    })
+  );
+
+  // 結果をオブジェクトに変換
+  const resultMap: Record<string, SearchResult[]> = {};
+  for (const { tableName, results: tableResults } of results) {
+    if (tableResults.length > 0) {
+      resultMap[tableName] = tableResults;
+    }
+  }
+
+  return resultMap;
+}

--- a/src/search-cards.ts
+++ b/src/search-cards.ts
@@ -550,14 +550,11 @@ async function main(){
     if(otherKeys.length>0){ console.error('mode partial is only allowed when filtering by name'); process.exit(2) }
   }
 
-  // Find project root (where package.json is)
-  const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
-  const projectRoot = await findProjectRoot(__dirname)
-  
-  const dataDir = path.join(projectRoot, 'data')
-  const cardsFile = path.join(dataDir,'cards-all.tsv')
-  const detailFile = path.join(dataDir,'detail-all.tsv')
-  if(!fs.existsSync(cardsFile) || !fs.existsSync(detailFile)){ console.error(`data files not found at ${dataDir}`); process.exit(2) }
+  // Get TSV file paths
+  const { getTsvPath } = await import('./lib/config/paths.js')
+  const cardsFile = getTsvPath('cards-all.tsv')
+  const detailFile = getTsvPath('detail-all.tsv')
+  if(!fs.existsSync(cardsFile) || !fs.existsSync(detailFile)){ console.error(`data files not found: ${cardsFile}, ${detailFile}`); process.exit(2) }
 
   const rl = readline.createInterface({ input: fs.createReadStream(cardsFile), crlfDelay: Infinity })
   let headers: string[] = []


### PR DESCRIPTION
## 概要

Vector検索（意味的検索）機能を実装し、カード、FAQ、ルールを意味的な類似性で検索できるようにしました。

## 主な変更

### Vector検索機能

#### 汎用データインポート（convertGenericToJsonl）
- 対応フォーマット: yaml, jsonl, json, tsv, csv
- 必須フィールド: id, title, text
- 再帰的抽出: yaml/jsonでネストされたオブジェクトから自動抽出
- カラムフィルタリング: `--include-columns` / `--exclude-columns`（相互排他）
- 階層構造対応: JSON/YAMLの階層パスを【階層】として自動追加

#### CLIコマンド
- `vector setup`: cards/faqs/allのインデックス構築
- `vector setup-generic`: 汎用データのインポート
- `vector search`: 全テーブル検索（--type all/cards/faqs/custom）

#### 検索機能の改善
- `searchAll`: カスタムテーブルも含む全テーブル並列検索に対応
- `searchTable`: 任意のテーブル名を検索可能
- `listTables`: 利用可能なテーブル一覧取得

### ライブラリエクスポート

以下の関数をライブラリから使用可能に：
- Vector検索: `vectorSearchCards`, `vectorSearchFaqs`, `vectorSearchAll`, `searchTable`, `listTables`
- 変換関数: `convertCardsToJsonl`, `convertFaqsToJsonl`, `convertGenericToJsonl`, `indexFromJsonl`
- 型定義: `VectorSearchResult`, `VectorSearchOptions`, `GenericConversionOptions`等

## ドキュメント更新

### README.md
- Vector検索機能の説明を追加
- ライブラリとしての使用方法セクションを新規追加
- 全主要関数の使用例とimport例

### docs/usage/usage.md
- `ygo_search vector`コマンドの詳細ドキュメント
- ライブラリ使用方法の詳細セクション
  - カード検索、FAQ検索
  - パターン抽出・置換
  - Vector検索とDBセットアップ
- TypeScript型定義と環境変数の説明

## 技術詳細

- **Embeddingモデル**: multilingual-e5-small (384次元)
- **Vector DB**: LanceDB
- **距離メトリック**: cosine（デフォルト）/ l2 / dot
- **並列処理**: 複数テーブルの並列検索に対応

## テスト

- tmp/ref/rules/ のYAMLファイルで125件のルールデータをインポート成功
- 階層構造の抽出とVector検索が正常動作確認
- 本番環境に混入したテストテーブルを削除（cards, faqs, rulesのみ残存）

## 使用例

### CLI
```bash
# Vector DBセットアップ
ygo_search vector setup all

# 全テーブル検索
ygo_search vector search "墓地から特殊召喚"

# ルールのみ検索
ygo_search vector search "チェーンブロック" --type rules --limit 5
```

### Library
```typescript
import { vectorSearchAll, searchTable } from 'ygo-search'

// 全テーブル検索
const results = await vectorSearchAll('融合召喚', { limit: 10 })

// カスタムテーブル検索
const rules = await searchTable('rules', 'ターンの流れ', { limit: 5 })
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)