### PR TITLE
feat: vector setup-generic の複数ファイル対応 + npm公開準備

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,48 @@
+MIT License
+
+Copyright (c) 2024 TomoTom0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## Data Disclaimer
+
+This software provides tools to search and process Yu-Gi-Oh! card data.
+The card data itself is copyrighted by KONAMI and is downloaded separately
+from external sources. This software does not include or distribute the
+card data. Users are responsible for ensuring their use of the data complies
+with applicable terms of service and copyright laws.
+
+Yu-Gi-Oh! is a trademark of KONAMI.
+
+---
+
+## Third Party Notices
+
+This software uses the following open source packages:
+
+- **LanceDB** (@lancedb/lancedb) - Apache-2.0 License
+  https://github.com/lancedb/lancedb
+
+- **Transformers.js** (@xenova/transformers) - Apache-2.0 License
+  https://github.com/xenova/transformers.js
+
+- **multilingual-e5-small** (ML model) - MIT License
+  https://huggingface.co/intfloat/multilingual-e5-small

--- a/README.md
+++ b/README.md
@@ -58,10 +58,22 @@ Automatically handles:
 
 ## Installation
 
+### From npm (Recommended)
+
+```bash
+# Install globally
+npm install -g ygo-search
+
+# Download card data (required for first use)
+ygo_search update
+```
+
+### From Source
+
 ```bash
 # Clone repository
-git clone https://github.com/TomoTom0/YuGiOh-Search-CLI.git
-cd YuGiOh-Search-CLI
+git clone https://github.com/TomoTom0/ygo-search.git
+cd ygo-search
 
 # Install dependencies
 bun install
@@ -73,10 +85,18 @@ bun run build
 bun link
 
 # Download card data (37.6MB total) - required for first use
-ygo_update_search
+ygo_search update
+```
 
-# Alternative: Download data manually
-bash scripts/setup/setup-data.sh
+### As a Library
+
+```bash
+# Add to your project
+npm install ygo-search
+# or
+pnpm add ygo-search
+# or
+bun add ygo-search
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ ygo_search docs Card                 # Show Card interface documentation
 ```bash
 node dist/cli/ygo_search.js card --name "青眼" --cols name,cardId
 node dist/cli/ygo_search.js extract "{青眼の白龍}"
-node dist/cli/ygo_search.js replace "{青眼}を召喚" --raw
+node dist/cli/ygo_search.js replace "{青眼の白龍}を召喚" --raw
 node dist/cli/ygo_search.js convert input.json:output.csv
 node dist/cli/ygo_search.js docs list
 ```

--- a/dist/cli/ygo_search.js
+++ b/dist/cli/ygo_search.js
@@ -981,14 +981,14 @@ Examples:
             console.error(`${inputFile} からJSONLに変換中...`);
             // 一時ファイルに変換してから追記
             const tempJsonlPath = getTmpPath(`${tableName}_temp.jsonl`);
+            tmpFiles.push(tempJsonlPath); // クリーンアップリストに追加
             const count = await convertGenericToJsonl(inputFile, tempJsonlPath, options);
             console.error(`  ${count}件のレコードを変換しました`);
             totalCount += count;
             // メインのJSONLファイルに追記
             const tempContent = await fs.readFile(tempJsonlPath, 'utf-8');
             await fs.appendFile(jsonlPath, tempContent);
-            // 一時ファイル削除
-            await fs.unlink(tempJsonlPath);
+        // 一時ファイルは関数の最後でまとめて削除するため、ここではunlinkしない
         }
         console.error(`合計 ${totalCount}件のレコードを変換しました`);
         console.error('Vector DBインデックスを構築中...');

--- a/dist/cli/ygo_search.js
+++ b/dist/cli/ygo_search.js
@@ -348,7 +348,8 @@ Examples:
   ygo_search card --name "青眼の白龍"
   ygo_search faq cardId=6808
   ygo_search extract "青眼の白龍とブラック・マジシャンを召喚"
-  ygo_search replace "{青眼}を召喚して攻撃"
+  ygo_search replace "{青眼の白龍}を召喚して攻撃"
+    # => {"processedText":"{{青眼の白龍|4007}}を召喚して攻撃",...}
   ygo_search seek
   ygo_search bulk '[{"name":"青眼"},{"name":"ブラック・マジシャン"}]'
   ygo_search convert input.json:output.yaml
@@ -614,8 +615,12 @@ Pattern Types:
   {{name|cardId}}     カードID で検索
 
 Examples:
-  ygo_search replace "{青眼}を召喚して攻撃"
-  ygo_search replace "Use {ブルーアイズ*} and 《青眼の白龍》"
+  ygo_search replace "{青眼の白龍}を召喚して攻撃"
+    # => {"processedText":"{{青眼の白龍|4007}}を召喚して攻撃",...}
+  ygo_search replace "{青眼*}を召喚"
+    # => 複数候補: {{青眼の白龍|4007}}, {{青眼の亜白龍|12253}}, ...
+  ygo_search replace "《青眼の白龍》を召喚" --mount-par
+    # => 《青眼の白龍》を召喚（完全一致、そのまま維持）
 `);
         process.exit(0);
     }
@@ -660,10 +665,11 @@ Subcommands:
                         type: cards, faqs, all (デフォルト: all)
                         Options:
                           --keep-tmp    一時JSONLファイルを削除せずに保持
-  setup-generic <file> <table>  汎用データをインポート
-                        file: yaml/jsonl/json/tsv/csv
-                        table: テーブル名
+  setup-generic <files...> --table <name>
+                        汎用データをインポート
+                        files: yaml/jsonl/json/tsv/csv（複数指定可、glob対応）
                         Options:
+                          --table <name>  テーブル名（必須）
                           --exclude-columns col1,col2
                           --include-columns col1,col2
                           --keep-tmp
@@ -674,8 +680,8 @@ Examples:
   ygo_search vector setup cards          カードのみ
   ygo_search vector setup faqs           FAQのみ
   ygo_search vector setup --keep-tmp     一時ファイルを保持
-  ygo_search vector setup-generic rules.yml rules --exclude-columns cite
-  ygo_search vector setup-generic data.json custom --include-columns category
+  ygo_search vector setup-generic rules.yml --table rules --exclude-columns cite
+  ygo_search vector setup-generic aa/*.yml bb/data.yml --table rules
   ygo_search vector search "墓地から特殊召喚" --limit 5
   ygo_search vector search "融合召喚" --type cards --threshold 0.8
 `);
@@ -887,46 +893,60 @@ Examples:
     }
 }
 async function handleVectorSetupGenericCommand(args) {
-    if (args.length < 2 || args[0] === '--help' || args[0] === '-h') {
-        console.log(`Usage: ygo_search vector setup-generic <inputFile> <tableName> [options]
+    if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+        console.log(`Usage: ygo_search vector setup-generic <files...> --table <tableName> [options]
 
 汎用データからVector DBインデックスを構築
 
 Arguments:
-  inputFile             入力ファイル（yaml/jsonl/json/tsv/csv）
-  tableName             テーブル名
+  files...              入力ファイル（yaml/jsonl/json/tsv/csv）
+                        複数ファイル指定可、シェルのglob展開に対応
 
 Options:
-  --exclude-columns col1,col2    指定カラムをテキストから除外
-  --include-columns col1,col2    指定カラムのみテキストに含める
-  --keep-tmp                     一時JSONLファイルを削除せずに保持
+  --table <name>               テーブル名（必須）
+  --exclude-columns col1,col2  指定カラムをテキストから除外
+  --include-columns col1,col2  指定カラムのみテキストに含める
+  --keep-tmp                   一時JSONLファイルを削除せずに保持
 
 Required fields: id, title, text
 
 Examples:
-  ygo_search vector setup-generic rules.yml rules
-  ygo_search vector setup-generic data.json custom --exclude-columns cite,sourceFile
-  ygo_search vector setup-generic items.tsv items --include-columns category,priority
+  ygo_search vector setup-generic rules.yml --table rules
+  ygo_search vector setup-generic aa/*.yml bb/data.yml --table rules --exclude-columns cite
+  ygo_search vector setup-generic data.json --table custom --include-columns category,priority
 `);
         process.exit(0);
     }
     const { convertGenericToJsonl } = await import('../lib/vector/converter.js');
     const { indexFromJsonl } = await import('../lib/vector/indexer.js');
     const fs = await import('fs/promises');
-    const inputFile = args[0];
-    const tableName = args[1];
     // オプション解析
+    let tableName = undefined;
     let excludeColumns = undefined;
     let includeColumns = undefined;
     let keepTmp = false;
-    for(let i = 2; i < args.length; i++){
-        if (args[i] === '--exclude-columns' && i + 1 < args.length) {
+    const inputFiles = [];
+    for(let i = 0; i < args.length; i++){
+        if (args[i] === '--table' && i + 1 < args.length) {
+            tableName = args[++i];
+        } else if (args[i] === '--exclude-columns' && i + 1 < args.length) {
             excludeColumns = args[++i].split(',').map((c)=>c.trim());
         } else if (args[i] === '--include-columns' && i + 1 < args.length) {
             includeColumns = args[++i].split(',').map((c)=>c.trim());
         } else if (args[i] === '--keep-tmp') {
             keepTmp = true;
+        } else if (!args[i].startsWith('--')) {
+            inputFiles.push(args[i]);
         }
+    }
+    // バリデーション
+    if (!tableName) {
+        console.error('Error: --table オプションは必須です');
+        process.exit(1);
+    }
+    if (inputFiles.length === 0) {
+        console.error('Error: 入力ファイルを指定してください');
+        process.exit(1);
     }
     // Validate exclusivity
     if (excludeColumns && includeColumns) {
@@ -945,14 +965,32 @@ Examples:
         console.error(`\n=== ${tableName} のインデックス構築 ===`);
         const jsonlPath = getTmpPath(`${tableName}_for_vectordb.jsonl`);
         tmpFiles.push(jsonlPath);
-        console.error(`${inputFile} からJSONLに変換中...`);
+        // 既存のJSONLファイルを削除（追記モードのため）
+        try {
+            await fs.unlink(jsonlPath);
+        } catch (e) {
+            if (e.code !== 'ENOENT') throw e;
+        }
         const options = excludeColumns ? {
             excludeColumns
         } : includeColumns ? {
             includeColumns
         } : undefined;
-        const count = await convertGenericToJsonl(inputFile, jsonlPath, options);
-        console.error(`${count}件のレコードを変換しました`);
+        let totalCount = 0;
+        for (const inputFile of inputFiles){
+            console.error(`${inputFile} からJSONLに変換中...`);
+            // 一時ファイルに変換してから追記
+            const tempJsonlPath = getTmpPath(`${tableName}_temp.jsonl`);
+            const count = await convertGenericToJsonl(inputFile, tempJsonlPath, options);
+            console.error(`  ${count}件のレコードを変換しました`);
+            totalCount += count;
+            // メインのJSONLファイルに追記
+            const tempContent = await fs.readFile(tempJsonlPath, 'utf-8');
+            await fs.appendFile(jsonlPath, tempContent);
+            // 一時ファイル削除
+            await fs.unlink(tempJsonlPath);
+        }
+        console.error(`合計 ${totalCount}件のレコードを変換しました`);
         console.error('Vector DBインデックスを構築中...');
         await indexFromJsonl(tableName, jsonlPath);
         console.error('\nインデックス構築が完了しました');

--- a/docs/usage/build-and-run.md
+++ b/docs/usage/build-and-run.md
@@ -57,7 +57,8 @@ bun link
 # 任意の場所でコマンド使用可能
 ygo_search card --name "青眼" --cols name,cardId
 ygo_search extract "{青眼の白龍}"
-ygo_search replace "{青眼}を召喚"
+ygo_search replace "{青眼の白龍}を召喚"
+# => {"processedText":"{{青眼の白龍|4007}}を召喚",...}
 ygo_search seek --max 10
 ygo_search faq cardId=6808
 ygo_search docs list
@@ -69,7 +70,8 @@ ygo_search docs list
 # グローバルインストール不要
 node dist/cli/ygo_search.js card --name "青眼" --cols name,cardId
 node dist/cli/ygo_search.js extract "{青眼の白龍}"
-node dist/cli/ygo_search.js replace "{青眼}を召喚"
+node dist/cli/ygo_search.js replace "{青眼の白龍}を召喚"
+# => {"processedText":"{{青眼の白龍|4007}}を召喚",...}
 node dist/cli/ygo_search.js seek --max 10
 node dist/cli/ygo_search.js faq cardId=6808
 node dist/cli/ygo_search.js docs list

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -204,10 +204,13 @@ ygo_search vector setup faqs     # FAQのみ
 ygo_search vector setup all      # 全て
 
 # ルールデータのインポート（YAML形式）
-ygo_search vector setup-generic rules.yml rules --include-columns name,notes,examples
+ygo_search vector setup-generic rules.yml --table rules --include-columns name,notes,examples
+
+# 複数ファイルのインポート（glob展開・併記対応）
+ygo_search vector setup-generic aa/*.yml bb/data.yml --table rules
 
 # 汎用データのインポート（yaml/json/jsonl/tsv/csv対応）
-ygo_search vector setup-generic data.json custom-table
+ygo_search vector setup-generic data.json --table custom-table
 ```
 
 #### 検索
@@ -246,13 +249,16 @@ ygo_search vector search "墓地" --distance dot
 # その他のフィールドは自動的に検索テキストに含まれる
 
 # 特定カラムのみ含める
-ygo_search vector setup-generic data.yml table --include-columns name,notes,examples
+ygo_search vector setup-generic data.yml --table mytable --include-columns name,notes,examples
 
 # 特定カラムを除外
-ygo_search vector setup-generic data.json table --exclude-columns cite,sourceFile
+ygo_search vector setup-generic data.json --table mytable --exclude-columns cite,sourceFile
 
 # 一時JSONLファイルを保持（デバッグ用）
-ygo_search vector setup-generic data.yml table --keep-tmp
+ygo_search vector setup-generic data.yml --table mytable --keep-tmp
+
+# 複数ファイル指定（シェルのglob展開を利用）
+ygo_search vector setup-generic rules/*.yml --table rules
 
 # 対応フォーマット:
 # - YAML (.yml, .yaml) - 階層構造から自動抽出

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "files": [
     "dist",
-    "data",
     "README.md",
     "LICENSE"
   ],
@@ -36,10 +35,21 @@
   },
   "keywords": [
     "mcp",
-    "yugioh"
+    "yugioh",
+    "card-search",
+    "ocg",
+    "cli"
   ],
-  "author": "",
-  "license": "ISC",
+  "author": "TomoTom0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TomoTom0/ygo-search.git"
+  },
+  "homepage": "https://github.com/TomoTom0/ygo-search#readme",
+  "bugs": {
+    "url": "https://github.com/TomoTom0/ygo-search/issues"
+  },
+  "license": "MIT",
   "dependencies": {
     "@lancedb/lancedb": "^0.23.0",
     "@xenova/transformers": "^2.17.2",

--- a/src/cli/ygo_search.ts
+++ b/src/cli/ygo_search.ts
@@ -239,7 +239,8 @@ Examples:
   ygo_search card --name "青眼の白龍"
   ygo_search faq cardId=6808
   ygo_search extract "青眼の白龍とブラック・マジシャンを召喚"
-  ygo_search replace "{青眼}を召喚して攻撃"
+  ygo_search replace "{青眼の白龍}を召喚して攻撃"
+    # => {"processedText":"{{青眼の白龍|4007}}を召喚して攻撃",...}
   ygo_search seek
   ygo_search bulk '[{"name":"青眼"},{"name":"ブラック・マジシャン"}]'
   ygo_search convert input.json:output.yaml
@@ -508,8 +509,12 @@ Pattern Types:
   {{name|cardId}}     カードID で検索
 
 Examples:
-  ygo_search replace "{青眼}を召喚して攻撃"
-  ygo_search replace "Use {ブルーアイズ*} and 《青眼の白龍》"
+  ygo_search replace "{青眼の白龍}を召喚して攻撃"
+    # => {"processedText":"{{青眼の白龍|4007}}を召喚して攻撃",...}
+  ygo_search replace "{青眼*}を召喚"
+    # => 複数候補: {{青眼の白龍|4007}}, {{青眼の亜白龍|12253}}, ...
+  ygo_search replace "《青眼の白龍》を召喚" --mount-par
+    # => 《青眼の白龍》を召喚（完全一致、そのまま維持）
 `);
     process.exit(0);
   }
@@ -557,10 +562,11 @@ Subcommands:
                         type: cards, faqs, all (デフォルト: all)
                         Options:
                           --keep-tmp    一時JSONLファイルを削除せずに保持
-  setup-generic <file> <table>  汎用データをインポート
-                        file: yaml/jsonl/json/tsv/csv
-                        table: テーブル名
+  setup-generic <files...> --table <name>
+                        汎用データをインポート
+                        files: yaml/jsonl/json/tsv/csv（複数指定可、glob対応）
                         Options:
+                          --table <name>  テーブル名（必須）
                           --exclude-columns col1,col2
                           --include-columns col1,col2
                           --keep-tmp
@@ -571,8 +577,8 @@ Examples:
   ygo_search vector setup cards          カードのみ
   ygo_search vector setup faqs           FAQのみ
   ygo_search vector setup --keep-tmp     一時ファイルを保持
-  ygo_search vector setup-generic rules.yml rules --exclude-columns cite
-  ygo_search vector setup-generic data.json custom --include-columns category
+  ygo_search vector setup-generic rules.yml --table rules --exclude-columns cite
+  ygo_search vector setup-generic aa/*.yml bb/data.yml --table rules
   ygo_search vector search "墓地から特殊召喚" --limit 5
   ygo_search vector search "融合召喚" --type cards --threshold 0.8
 `);
@@ -792,26 +798,27 @@ Examples:
 }
 
 async function handleVectorSetupGenericCommand(args: string[]) {
-  if (args.length < 2 || args[0] === '--help' || args[0] === '-h') {
-    console.log(`Usage: ygo_search vector setup-generic <inputFile> <tableName> [options]
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(`Usage: ygo_search vector setup-generic <files...> --table <tableName> [options]
 
 汎用データからVector DBインデックスを構築
 
 Arguments:
-  inputFile             入力ファイル（yaml/jsonl/json/tsv/csv）
-  tableName             テーブル名
+  files...              入力ファイル（yaml/jsonl/json/tsv/csv）
+                        複数ファイル指定可、シェルのglob展開に対応
 
 Options:
-  --exclude-columns col1,col2    指定カラムをテキストから除外
-  --include-columns col1,col2    指定カラムのみテキストに含める
-  --keep-tmp                     一時JSONLファイルを削除せずに保持
+  --table <name>               テーブル名（必須）
+  --exclude-columns col1,col2  指定カラムをテキストから除外
+  --include-columns col1,col2  指定カラムのみテキストに含める
+  --keep-tmp                   一時JSONLファイルを削除せずに保持
 
 Required fields: id, title, text
 
 Examples:
-  ygo_search vector setup-generic rules.yml rules
-  ygo_search vector setup-generic data.json custom --exclude-columns cite,sourceFile
-  ygo_search vector setup-generic items.tsv items --include-columns category,priority
+  ygo_search vector setup-generic rules.yml --table rules
+  ygo_search vector setup-generic aa/*.yml bb/data.yml --table rules --exclude-columns cite
+  ygo_search vector setup-generic data.json --table custom --include-columns category,priority
 `);
     process.exit(0);
   }
@@ -820,22 +827,36 @@ Examples:
   const { indexFromJsonl } = await import('../lib/vector/indexer.js');
   const fs = await import('fs/promises');
 
-  const inputFile = args[0];
-  const tableName = args[1];
-
   // オプション解析
+  let tableName: string | undefined = undefined;
   let excludeColumns: string[] | undefined = undefined;
   let includeColumns: string[] | undefined = undefined;
   let keepTmp = false;
+  const inputFiles: string[] = [];
 
-  for (let i = 2; i < args.length; i++) {
-    if (args[i] === '--exclude-columns' && i + 1 < args.length) {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--table' && i + 1 < args.length) {
+      tableName = args[++i];
+    } else if (args[i] === '--exclude-columns' && i + 1 < args.length) {
       excludeColumns = args[++i].split(',').map(c => c.trim());
     } else if (args[i] === '--include-columns' && i + 1 < args.length) {
       includeColumns = args[++i].split(',').map(c => c.trim());
     } else if (args[i] === '--keep-tmp') {
       keepTmp = true;
+    } else if (!args[i].startsWith('--')) {
+      inputFiles.push(args[i]);
     }
+  }
+
+  // バリデーション
+  if (!tableName) {
+    console.error('Error: --table オプションは必須です');
+    process.exit(1);
+  }
+
+  if (inputFiles.length === 0) {
+    console.error('Error: 入力ファイルを指定してください');
+    process.exit(1);
   }
 
   // Validate exclusivity
@@ -859,10 +880,33 @@ Examples:
     const jsonlPath = getTmpPath(`${tableName}_for_vectordb.jsonl`);
     tmpFiles.push(jsonlPath);
 
-    console.error(`${inputFile} からJSONLに変換中...`);
+    // 既存のJSONLファイルを削除（追記モードのため）
+    try {
+      await fs.unlink(jsonlPath);
+    } catch (e: any) {
+      if (e.code !== 'ENOENT') throw e;
+    }
+
     const options = excludeColumns ? { excludeColumns } : includeColumns ? { includeColumns } : undefined;
-    const count = await convertGenericToJsonl(inputFile, jsonlPath, options);
-    console.error(`${count}件のレコードを変換しました`);
+    let totalCount = 0;
+
+    for (const inputFile of inputFiles) {
+      console.error(`${inputFile} からJSONLに変換中...`);
+      // 一時ファイルに変換してから追記
+      const tempJsonlPath = getTmpPath(`${tableName}_temp.jsonl`);
+      const count = await convertGenericToJsonl(inputFile, tempJsonlPath, options);
+      console.error(`  ${count}件のレコードを変換しました`);
+      totalCount += count;
+
+      // メインのJSONLファイルに追記
+      const tempContent = await fs.readFile(tempJsonlPath, 'utf-8');
+      await fs.appendFile(jsonlPath, tempContent);
+
+      // 一時ファイル削除
+      await fs.unlink(tempJsonlPath);
+    }
+
+    console.error(`合計 ${totalCount}件のレコードを変換しました`);
 
     console.error('Vector DBインデックスを構築中...');
     await indexFromJsonl(tableName, jsonlPath);

--- a/src/cli/ygo_search.ts
+++ b/src/cli/ygo_search.ts
@@ -894,6 +894,8 @@ Examples:
       console.error(`${inputFile} からJSONLに変換中...`);
       // 一時ファイルに変換してから追記
       const tempJsonlPath = getTmpPath(`${tableName}_temp.jsonl`);
+      tmpFiles.push(tempJsonlPath); // クリーンアップリストに追加
+
       const count = await convertGenericToJsonl(inputFile, tempJsonlPath, options);
       console.error(`  ${count}件のレコードを変換しました`);
       totalCount += count;
@@ -902,8 +904,7 @@ Examples:
       const tempContent = await fs.readFile(tempJsonlPath, 'utf-8');
       await fs.appendFile(jsonlPath, tempContent);
 
-      // 一時ファイル削除
-      await fs.unlink(tempJsonlPath);
+      // 一時ファイルは関数の最後でまとめて削除するため、ここではunlinkしない
     }
 
     console.error(`合計 ${totalCount}件のレコードを変換しました`);


### PR DESCRIPTION
## 変更内容

### 機能追加
- `vector setup-generic` コマンドで複数ファイルを一度に処理可能に
- `replace` コマンドのヘルプ例を修正

### npm公開準備
- MITライセンスの追加（データ免責事項・サードパーティ通知付き）
- README.mdのインストール手順を改善（npm/ソース/ライブラリ）
- package.jsonのメタデータ更新（author, repository, keywords, license）

## 変更ファイル

- `src/cli/ygo_search.ts` - 複数ファイル対応
- `docs/usage/usage.md`, `docs/usage/build-and-run.md` - ドキュメント更新
- `LICENSE` - 新規追加
- `README.md` - インストール手順改善
- `package.json` - メタデータ更新