### PR TITLE
fix: faq-loaderのTSVパス解決をgetTsvPath()に修正

### DIFF
--- a/dist/utils/faq-loader.js
+++ b/dist/utils/faq-loader.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
-import path from 'path';
 import readline from 'readline';
-import { findProjectRoot } from './project-root.js';
+import { getTsvPath } from '../lib/config/paths.js';
 let cachedIndex = null;
 let cardsCache = null;
 export function extractCardReferences(text) {
@@ -95,8 +94,7 @@ function isTrapEffectType(value) {
 }
 async function loadCards() {
     if (cardsCache) return cardsCache;
-    const projectRoot = await findProjectRoot();
-    const cardsPath = path.join(projectRoot, 'data', 'cards-all.tsv');
+    const cardsPath = getTsvPath('cards-all.tsv');
     if (!fs.existsSync(cardsPath)) {
         throw new Error(`カードデータファイルが見つかりません: ${cardsPath}\n\n以下のコマンドでデータをダウンロードしてください:\n  ygo_update_search`);
     }
@@ -144,8 +142,7 @@ async function loadCards() {
 }
 export async function loadFAQIndex() {
     if (cachedIndex) return cachedIndex;
-    const projectRoot = await findProjectRoot();
-    const faqPath = path.join(projectRoot, 'data', 'faq-all.tsv');
+    const faqPath = getTsvPath('faq-all.tsv');
     if (!fs.existsSync(faqPath)) {
         throw new Error(`FAQデータファイルが見つかりません: ${faqPath}\n\n以下のコマンドでデータをダウンロードしてください:\n  ygo_update_search`);
     }

--- a/src/utils/faq-loader.ts
+++ b/src/utils/faq-loader.ts
@@ -1,9 +1,8 @@
 import fs from 'fs'
-import path from 'path'
 import readline from 'readline'
 import { FAQRecord, FAQIndex, CardReference } from '../types/faq.js'
 import { Card, CardType, Attribute, LevelType, Race, SpellEffectType, TrapEffectType } from '../types/card.js'
-import { findProjectRoot } from './project-root.js'
+import { getTsvPath } from '../lib/config/paths.js'
 
 let cachedIndex: FAQIndex | null = null
 let cardsCache: Map<string, Card> | null = null
@@ -66,8 +65,7 @@ function isTrapEffectType(value: string): value is TrapEffectType {
 async function loadCards(): Promise<Map<string, Card>> {
   if (cardsCache) return cardsCache
 
-  const projectRoot = await findProjectRoot()
-  const cardsPath = path.join(projectRoot, 'data', 'cards-all.tsv')
+  const cardsPath = getTsvPath('cards-all.tsv')
 
   if (!fs.existsSync(cardsPath)) {
     throw new Error(`カードデータファイルが見つかりません: ${cardsPath}\n\n以下のコマンドでデータをダウンロードしてください:\n  ygo_update_search`)
@@ -122,8 +120,7 @@ async function loadCards(): Promise<Map<string, Card>> {
 export async function loadFAQIndex(): Promise<FAQIndex> {
   if (cachedIndex) return cachedIndex
 
-  const projectRoot = await findProjectRoot()
-  const faqPath = path.join(projectRoot, 'data', 'faq-all.tsv')
+  const faqPath = getTsvPath('faq-all.tsv')
 
   if (!fs.existsSync(faqPath)) {
     throw new Error(`FAQデータファイルが見つかりません: ${faqPath}\n\n以下のコマンドでデータをダウンロードしてください:\n  ygo_update_search`)


### PR DESCRIPTION
## 変更内容

- faq-loader.tsが`findProjectRoot()`ではなく`getTsvPath()`を使用するように修正
- TSVファイルの読み取りパスが`~/.local/ygo-search/data/tsv/`を参照するようになった

## 修正内容

`faq-loader.ts`で以下の問題を修正：
- `findProjectRoot()` + `data/faq-all.tsv` -> `getTsvPath('faq-all.tsv')`
- `findProjectRoot()` + `data/cards-all.tsv` -> `getTsvPath('cards-all.tsv')`

## テスト

- [x] ビルド成功確認