### PR TITLE
fix: ローカルD1と本番D1の分離、wrangler dev動作確認完了

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ ygo_search update
 # Initialize local D1 database
 npx wrangler d1 execute ygo-search-db --local --file=migrations/0001_api_keys_and_logs.sql
 
-# Create cards and faqs tables (get schema from remote)
-npx wrangler d1 execute ygo-search-db --remote --command "SELECT sql FROM sqlite_master WHERE type='table' AND name IN ('cards', 'faqs')"
-# Copy the output SQL and execute it locally
+# Create cards, faqs, and other tables from schema file
+npx wrangler d1 execute ygo-search-db --local --file=rust/schema.sql
 
 # Start development server (uses local D1 by default)
 # IMPORTANT: Use --local flag to avoid remote resource connection issues

--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ bun link
 ygo_search update
 ```
 
+### Development Setup (For Contributors)
+
+**IMPORTANT**: Local development uses local D1 database to prevent accidentally modifying production data.
+
+```bash
+# Initialize local D1 database
+npx wrangler d1 execute ygo-search-db --local --file=migrations/0001_api_keys_and_logs.sql
+
+# Create cards and faqs tables (get schema from remote)
+npx wrangler d1 execute ygo-search-db --remote --command "SELECT sql FROM sqlite_master WHERE type='table' AND name IN ('cards', 'faqs')"
+# Copy the output SQL and execute it locally
+
+# Start development server (uses local D1 by default)
+# IMPORTANT: Use --local flag to avoid remote resource connection issues
+npx wrangler dev --local --port 40040
+
+# Deploy to production (uses remote D1)
+npx wrangler deploy
+```
+
+**Note**:
+- `wrangler.toml` is configured with `preview_database_id = "local"` to ensure local development never touches production data.
+- Use `--local` flag to run in fully local mode (Vectorize and AI resources will be unavailable but not required for basic API testing).
+
 ### As a Library
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,14 @@
 # 本番デプロイ手順
 
+## ⚠️ 重要: ローカル開発と本番環境の分離
+
+**ローカル開発では必ずローカルD1を使用してください。本番D1に直接アクセスしないでください。**
+
+- **ローカル開発**: `wrangler dev` → ローカルD1を使用（`preview_database_id = "local"`により自動）
+- **本番デプロイ**: `wrangler deploy` → 本番D1を使用
+
+詳細は[README.md - Development Setup](../README.md#development-setup-for-contributors)を参照してください。
+
 ## 前提条件
 
 - Cloudflareアカウント

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,10 +8,14 @@ compatibility_date = "2024-01-01"
 # binding = "ANALYTICS"
 
 # D1 Database
+# Contains: cards, faqs, api_keys, api_logs tables
+# Development: Uses local D1 (persisted SQLite file)
+# Production: Uses remote D1 (override with database_id in production deployment)
 [[d1_databases]]
 binding = "DB"
 database_name = "ygo-search-db"
 database_id = "1d6b90bc-b61a-4f61-8d3d-63822422db52"
+preview_database_id = "local"
 
 # Workers AI
 [ai]


### PR DESCRIPTION
## 変更内容

ローカル開発環境と本番環境でのD1データベースを完全に分離し、誤って本番データを変更するリスクを排除しました。

### 主な変更

1. **wrangler.toml**: `preview_database_id = "local"` を追加
   - `wrangler dev`実行時に自動的にローカルD1を使用
   - 本番D1への誤アクセスを防止

2. **README.md**: Development Setupセクションを追加
   - ローカルD1の初期化手順を明記
   - `wrangler dev --local`フラグの使用を推奨

3. **docs/deployment.md**: 警告セクションを追加
   - ローカル開発と本番環境の分離について明記
   - 開発者への注意喚起

### 動作確認

- ✅ 本番環境: verify-deployment.sh実行（12/12テスト成功）
- ✅ ローカル環境: wrangler dev --local起動成功、認証テスト4/4成功

## テスト

- [x] 本番環境での動作確認完了
- [x] ローカル環境での動作確認完了
- [x] ドキュメント更新完了

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>