### PR TITLE
feat: Rust SDK CI featureマトリクス(TASK-19) + Release v1.5.0

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -32,9 +32,9 @@ pnpm run test:watch
 Runs on every pull request and push to `main` and `dev` branches, plus manual dispatch. Verifies the Rust SDK (`crates/ygo-search`) across its feature matrix.
 
 **Jobs:**
-- `native-matrix`: `cargo check` + `cargo test` for each feature combination (`default` / `fs` / `format` / `fs+format` / `vector`). Tests run single-threaded (`--test-threads=1`) to respect SERIAL env guards.
+- `native-matrix`: `cargo check` + `cargo test` for each feature combination (`default` / `fs` / `format` / `fs+format` / `vector-search` / `vector`). `vector-search` is checked standalone (independent of `fs`) as well as via the `vector` umbrella. Tests run single-threaded (`--test-threads=1`) to respect SERIAL env guards.
 - `wasm32-success`: Confirms the core crate (Layer A) and the `ygo-search-workers` crate compile on `wasm32-unknown-unknown`.
-- `wasm32-compile-fail`: Confirms native-only features (`fs` / `format` / `vector-search` / `vector-index`) are rejected on `wasm32` via `compile_error!` (or upstream dependency failure).
+- `wasm32-compile-fail`: Confirms native-only features (`fs` / `format` / `vector-search` / `vector-index`) are rejected on `wasm32`. The failure is strictly validated against an allow-list: it must contain either the feature-specific `compile_error!` message or the known `getrandom` upstream dependency error — unrelated dependency or compiler-regression failures fail the job.
 
 `--all-features` is intentionally not run (the wasm32 exclusion is expected to fail compilation). Uses `Swatinem/rust-cache` and `--locked`.
 

--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -32,7 +32,7 @@ pnpm run test:watch
 Runs on every pull request and push to `main` and `dev` branches, plus manual dispatch. Verifies the Rust SDK (`crates/ygo-search`) across its feature matrix.
 
 **Jobs:**
-- `native-matrix`: `cargo check` + `cargo test` for each feature combination (`default` / `fs` / `format` / `fs+format` / `vector-search` / `vector`). `vector-search` is checked standalone (independent of `fs`) as well as via the `vector` umbrella. Tests run single-threaded (`--test-threads=1`) to respect SERIAL env guards.
+- `native-matrix`: `cargo check` + `cargo test` for each feature combination (`default` / `fs` / `format` / `fs+format` / `vector-search` / `vector`). `vector-search` is checked standalone (independent of `fs`) as well as via the `vector` umbrella. The `vector` rows install `protoc` via `apt-get` (required by the `lancedb` dependency, absent from the default `ubuntu-latest` image). Tests run single-threaded (`--test-threads=1`) to respect SERIAL env guards.
 - `wasm32-success`: Confirms the core crate (Layer A) and the `ygo-search-workers` crate compile on `wasm32-unknown-unknown`.
 - `wasm32-compile-fail`: Confirms native-only features (`fs` / `format` / `vector-search` / `vector-index`) are rejected on `wasm32`. The failure is strictly validated against an allow-list: it must contain either the feature-specific `compile_error!` message or the known `getrandom` upstream dependency error — unrelated dependency or compiler-regression failures fail the job.
 

--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -6,40 +6,70 @@ This project uses GitHub Actions for continuous integration.
 
 ### Unit Tests (`.github/workflows/test.yml`)
 
-Runs on every pull request and push to `main` and `mcp_new` branches.
+Runs on every pull request and push to `main` and `dev` branches.
 
-**What it does:**
-- Tests on Node.js 18.x and 20.x
-- Runs unit tests only (no TSV data required)
-- Checks TypeScript compilation
-- Uploads test artifacts
+**Jobs:**
+- `unit-tests` (Node.js 20.x / 22.x matrix): installs deps (`pnpm install --frozen-lockfile`), builds with swc, runs unit tests (`pnpm test:unit`), and uploads test results.
+- `lint` (Node.js 20.x): installs deps and runs the swc build (TypeScript compile check).
 
 **Local testing:**
 ```bash
 # Run unit tests (same as CI)
-npm run test:unit
+pnpm run test:unit
 
 # Run all tests (requires TSV data)
-npm test
+pnpm test
 
 # Run integration tests (requires TSV data)
-npm run test:integration
+pnpm run test:integration
 
 # Watch mode for development
-npm run test:watch
+pnpm run test:watch
 ```
+
+### Rust CI (`.github/workflows/rust-ci.yml`)
+
+Runs on every pull request and push to `main` and `dev` branches, plus manual dispatch. Verifies the Rust SDK (`crates/ygo-search`) across its feature matrix.
+
+**Jobs:**
+- `native-matrix`: `cargo check` + `cargo test` for each feature combination (`default` / `fs` / `format` / `fs+format` / `vector`). Tests run single-threaded (`--test-threads=1`) to respect SERIAL env guards.
+- `wasm32-success`: Confirms the core crate (Layer A) and the `ygo-search-workers` crate compile on `wasm32-unknown-unknown`.
+- `wasm32-compile-fail`: Confirms native-only features (`fs` / `format` / `vector-search` / `vector-index`) are rejected on `wasm32` via `compile_error!` (or upstream dependency failure).
+
+`--all-features` is intentionally not run (the wasm32 exclusion is expected to fail compilation). Uses `Swatinem/rust-cache` and `--locked`.
+
+**Local testing:**
+```bash
+# native feature matrix (per feature)
+cargo test -p ygo-search --features fs -- --test-threads=1
+
+# wasm32 success path
+cargo check -p ygo-search-workers --target wasm32-unknown-unknown
+
+# wasm32 compile-fail (expect non-zero exit)
+cargo check -p ygo-search --features format --target wasm32-unknown-unknown
+```
+
+### PR Validation (`.github/workflows/pr-validation.yml`)
+
+Runs on pull requests targeting `main`. Enforces that the source branch is `dev` (`main` is updated only via PRs from `dev`, per the branch protection policy).
 
 ## Test Organization
 
 ### Unit Tests (`tests/unit/`)
-- ✅ Run in CI/CD (no data dependencies)
+- Run in CI/CD (no data dependencies)
 - Test pure logic: pattern extraction, replacement, mock data
 - Fast execution (~100-200ms)
 
 ### Integration Tests (`tests/integration/`)
-- ❌ Not run in CI/CD (require TSV data files)
+- Not run in CI/CD (require TSV data files)
 - Test actual CLI scripts with real data
 - Run locally before committing
+
+### Rust SDK Tests (`crates/ygo-search/tests/`)
+- Run in Rust CI (`rust-ci.yml`) under each feature flag
+- Feature-gated via `#![cfg(feature = "...")]` at the top of each test file
+- Tests requiring model files are marked `#[ignore]` (run manually via `YGO_SEARCH_MODEL_DIR`)
 
 ## Adding New Tests
 
@@ -55,4 +85,5 @@ npm run test:watch
 
 ## CI/CD Status
 
-[![Unit Tests](https://github.com/TomoTom0/ygo-db-local-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/TomoTom0/ygo-db-local-mcp/actions/workflows/test.yml)
+[![Unit Tests](https://github.com/TomoTom0/YuGiOh-Search-CLI/actions/workflows/test.yml/badge.svg)](https://github.com/TomoTom0/YuGiOh-Search-CLI/actions/workflows/test.yml)
+[![Rust CI](https://github.com/TomoTom0/YuGiOh-Search-CLI/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/TomoTom0/YuGiOh-Search-CLI/actions/workflows/rust-ci.yml)

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,140 @@
+name: rust-ci
+
+# Rust SDK (crates/ygo-search) の feature マトリクス CI。
+# design.md 第6節・development-plan.md M4-T1 に基づく。
+# - default/fs/format/fs+format/vector を個別に cargo check+test（native）
+# - core (Layer A) と workers crate が wasm32 target でビルド可能ことを検証
+# - wasm32 × native-only feature が compile_error! で排他されることを検証
+# --all-features は流さない（compile-fail を期待するため）。
+on:
+  pull_request:
+    branches: [main, dev]
+  push:
+    branches: [main, dev]
+  workflow_dispatch: {}
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  # ---------------------------------------------------------------
+  # Job 1: native feature マトリクス (cargo check + cargo test)
+  #   SERIAL env ガードがプロセス内 Mutex のため --test-threads=1 を常時付与。
+  #   fs+format は jsonl.rs / fs/mod.rs の両 feature gated コードをカバー。
+  # ---------------------------------------------------------------
+  native-matrix:
+    name: check+test (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            flags: ""
+          - name: fs
+            flags: "--features fs"
+          - name: format
+            flags: "--features format"
+          - name: fs+format
+            flags: "--features fs,format"
+          - name: vector
+            flags: "--features vector"
+    steps:
+      - uses: actions/checkout@v4
+
+      # rust-toolchain.toml が rustup により自動適用される
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: native-${{ matrix.name }}
+
+      - name: cargo check
+        run: cargo check -p ygo-search ${{ matrix.flags }} --locked --all-targets
+
+      - name: cargo test
+        run: cargo test -p ygo-search ${{ matrix.flags }} --locked -- --test-threads=1
+
+  # ---------------------------------------------------------------
+  # Job 2: wasm32 成功ケース
+  #   core を default features (=空) で、workers crate を wasm32 target で検証。
+  #   workers crate の cdylib リンク検証 (worker-build/wrangler) は TASK-24 待ち。
+  # ---------------------------------------------------------------
+  wasm32-success:
+    name: wasm32 build (success)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm32-success
+
+      - name: core (Layer A) on wasm32
+        run: cargo check -p ygo-search --no-default-features --target wasm32-unknown-unknown --locked
+
+      - name: workers crate on wasm32
+        run: cargo check -p ygo-search-workers --target wasm32-unknown-unknown --locked
+
+  # ---------------------------------------------------------------
+  # Job 3: wasm32 compile-fail（排他 feature 検証）
+  #   候補B: shell で exit code≠0 を期待し、check_msg=true なら compile_error! メッセージまで厳格検証。
+  #   実証済み失敗モード:
+  #     format         -> compile_error! に到達 (check_msg=true)
+  #     fs/vector-*    -> 依存の getrandom が wasm32 で先に失敗し compile_error! 未到達 (check_msg=false)
+  #   いずれの経路でも native-only feature が wasm32 でビルド不可になることを保証する。
+  # ---------------------------------------------------------------
+  wasm32-compile-fail:
+    name: wasm32 compile-fail (${{ matrix.feature }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - feature: fs
+            msg: "feature `fs` is native-only"
+            check_msg: "false"
+          - feature: format
+            msg: "feature `format` is native-only"
+            check_msg: "true"
+          - feature: vector-search
+            msg: "feature `vector-search` is native-only"
+            check_msg: "false"
+          - feature: vector-index
+            msg: "feature `vector-index` is native-only"
+            check_msg: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm32-fail-${{ matrix.feature }}
+
+      - name: Verify compile_error! for ${{ matrix.feature }}
+        env:
+          FEATURE: ${{ matrix.feature }}
+          MSG: ${{ matrix.msg }}
+          CHECK_MSG: ${{ matrix.check_msg }}
+        run: |
+          set +e
+          out=$(cargo check -p ygo-search --features "$FEATURE" \
+                  --target wasm32-unknown-unknown --locked 2>&1)
+          code=$?
+          printf '%s\n' "$out"
+          if [ "$code" -eq 0 ]; then
+            echo "::error::expected failure but 'cargo check --features $FEATURE' succeeded on wasm32"
+            exit 1
+          fi
+          if [ "$CHECK_MSG" = "true" ]; then
+            if ! printf '%s\n' "$out" | grep -qF "$MSG"; then
+              echo "::error::cargo check failed but expected compile_error! message not found: $MSG"
+              exit 1
+            fi
+            echo "OK: compile_error! message verified for '$FEATURE'"
+          else
+            if printf '%s\n' "$out" | grep -qF "$MSG"; then
+              echo "OK: compile_error! message found for '$FEATURE' (bonus)"
+            else
+              echo "::warning::'$FEATURE' failed on wasm32 (expected) but compile_error! not reached (deps failed first)"
+            fi
+          fi
+          echo "DONE: '$FEATURE' correctly rejected on wasm32"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -46,6 +46,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # lancedb (vector/vector-search feature) の依存 lance-encoding ビルドに protoc が必要。
+      # ubuntu-latest 既定イメージに含まれないため、vector 系の行でのみインストールする。
+      - name: Install protoc
+        if: contains(matrix.flags, 'vector')
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
+
       # rust-toolchain.toml が rustup により自動適用される
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,7 +2,7 @@ name: rust-ci
 
 # Rust SDK (crates/ygo-search) の feature マトリクス CI。
 # design.md 第6節・development-plan.md M4-T1 に基づく。
-# - default/fs/format/fs+format/vector を個別に cargo check+test（native）
+# - default/fs/format/fs+format/vector-search/vector を個別に cargo check+test（native）
 # - core (Layer A) と workers crate が wasm32 target でビルド可能ことを検証
 # - wasm32 × native-only feature が compile_error! で排他されることを検証
 # --all-features は流さない（compile-fail を期待するため）。
@@ -38,6 +38,9 @@ jobs:
             flags: "--features format"
           - name: fs+format
             flags: "--features fs,format"
+          # vector-search 単体: fs に依存せず単独ビルド可能であることを検証（dep:dirs は共有するが fs feature は無関係）
+          - name: vector-search
+            flags: "--features vector-search"
           - name: vector
             flags: "--features vector"
     steps:
@@ -77,10 +80,13 @@ jobs:
 
   # ---------------------------------------------------------------
   # Job 3: wasm32 compile-fail（排他 feature 検証）
-  #   候補B: shell で exit code≠0 を期待し、check_msg=true なら compile_error! メッセージまで厳格検証。
+  #   shell で exit code≠0 を期待し、失敗理由を許可リスト方式で厳格検証する。
+  #   失敗は以下いずれかに合致すること（無関係な依存エラー/コンパイラリグレッション/ガイド破損を弾く）:
+  #     (a) feature 固有の compile_error! メッセージ ($MSG)
+  #     (b) 許可リストの既知依存エラー ($DEP_ERROR): getrandom の wasm32 非サポート
   #   実証済み失敗モード:
-  #     format         -> compile_error! に到達 (check_msg=true)
-  #     fs/vector-*    -> 依存の getrandom が wasm32 で先に失敗し compile_error! 未到達 (check_msg=false)
+  #     format         -> compile_error! に到達（メッセージ検証）
+  #     fs/vector-*    -> 依存 getrandom が wasm32 で先に失敗（getrandom エラーで検証）
   #   いずれの経路でも native-only feature が wasm32 でビルド不可になることを保証する。
   # ---------------------------------------------------------------
   wasm32-compile-fail:
@@ -92,16 +98,16 @@ jobs:
         include:
           - feature: fs
             msg: "feature `fs` is native-only"
-            check_msg: "false"
+            dep_error: "docs.rs/getrandom/"
           - feature: format
             msg: "feature `format` is native-only"
-            check_msg: "true"
+            dep_error: ""
           - feature: vector-search
             msg: "feature `vector-search` is native-only"
-            check_msg: "false"
+            dep_error: "docs.rs/getrandom/"
           - feature: vector-index
             msg: "feature `vector-index` is native-only"
-            check_msg: "false"
+            dep_error: "docs.rs/getrandom/"
     steps:
       - uses: actions/checkout@v4
 
@@ -113,7 +119,7 @@ jobs:
         env:
           FEATURE: ${{ matrix.feature }}
           MSG: ${{ matrix.msg }}
-          CHECK_MSG: ${{ matrix.check_msg }}
+          DEP_ERROR: ${{ matrix.dep_error }}
         run: |
           set +e
           out=$(cargo check -p ygo-search --features "$FEATURE" \
@@ -124,17 +130,13 @@ jobs:
             echo "::error::expected failure but 'cargo check --features $FEATURE' succeeded on wasm32"
             exit 1
           fi
-          if [ "$CHECK_MSG" = "true" ]; then
-            if ! printf '%s\n' "$out" | grep -qF "$MSG"; then
-              echo "::error::cargo check failed but expected compile_error! message not found: $MSG"
-              exit 1
-            fi
+          # 失敗理由の厳格検証: compile_error! メッセージ OR 許可リストの既知依存エラー
+          if printf '%s\n' "$out" | grep -qF "$MSG"; then
             echo "OK: compile_error! message verified for '$FEATURE'"
+          elif [ -n "$DEP_ERROR" ] && printf '%s\n' "$out" | grep -qF "$DEP_ERROR"; then
+            echo "OK: known dependency error (getrandom wasm32) verified for '$FEATURE' — compile_error! not reached but native-only still enforced"
           else
-            if printf '%s\n' "$out" | grep -qF "$MSG"; then
-              echo "OK: compile_error! message found for '$FEATURE' (bonus)"
-            else
-              echo "::warning::'$FEATURE' failed on wasm32 (expected) but compile_error! not reached (deps failed first)"
-            fi
+            echo "::error::cargo check failed for '$FEATURE' but neither compile_error! message ('$MSG') nor known dependency error ('$DEP_ERROR') found — possible unrelated dependency/compiler regression or compile_error! guard regression"
+            exit 1
           fi
           echo "DONE: '$FEATURE' correctly rejected on wasm32"

--- a/crates/ygo-search/src/lib.rs
+++ b/crates/ygo-search/src/lib.rs
@@ -15,8 +15,14 @@ pub mod vector;
 #[cfg(all(target_arch = "wasm32", feature = "fs"))]
 compile_error!("feature `fs` is native-only (file IO unavailable on wasm32)");
 
+#[cfg(all(target_arch = "wasm32", feature = "format"))]
+compile_error!("feature `format` is native-only on wasm32; use workers-side handling");
+
 #[cfg(all(target_arch = "wasm32", feature = "vector-search"))]
 compile_error!("feature `vector-search` is native-only (lancedb/ort cannot link to wasm32)");
+
+#[cfg(all(target_arch = "wasm32", feature = "vector-index"))]
+compile_error!("feature `vector-index` is native-only");
 
 #[cfg(test)]
 mod tests {

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,4 +56,5 @@ Web APIのデプロイと運用
 プロジェクトルートの重要なドキュメント：
 
 - [README.md](/README.md) - プロジェクト概要
+- [.github/CICD.md](/.github/CICD.md) - CI/CD 設定（test.yml / rust-ci.yml / pr-validation.yml）
 - [CHANGELOG.md](/CHANGELOG.md) - リリース履歴（バージョン v1.0.0 ～ v1.3.0）

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -2,63 +2,15 @@
 
 ## New Features
 
-- **APIキー管理システムの実装**
-  - ユーザーごとのAPIキー発行・管理機能
-  - APIキー管理エンドポイント（4個）
-    - `POST /api/keys` - APIキー発行（管理者のみ）
-    - `GET /api/keys` - APIキー一覧取得
-    - `DELETE /api/keys/:id` - APIキー無効化
-    - `GET /api/keys/logs` - API使用ログ取得
-  - D1データベーステーブル追加
-    - `api_keys` - APIキー情報（ユーザーID、スコープ、レート制限、有効期限）
-    - `api_logs` - 監査ログ（エンドポイント、メソッド、ステータス、IPアドレス等）
-  - 認証ミドルウェア拡張
-    - マスターキー OR ユーザーAPIキーの両対応
-    - 有効期限チェック
-    - スコープ情報取得
-  - 監査ログ機能
-    - 全APIリクエストを自動記録
-    - ユーザーAPIキー使用時のみログ記録
-- Cloudflare Workers API実装
-  - カード検索エンドポイント (`/api/cards/search`)
-  - FAQ検索エンドポイント (`/api/faqs/search`)
-  - セマンティック検索エンドポイント（カード・FAQ）
-  - 統計情報エンドポイント (`/api/stats`)
-  - レート制限機能（60リクエスト/分）
-  - キャッシュ機能（1時間TTL）
-- カード検索機能の実装（Phase 0完了）
-  - 種族検索（race）
-  - カード種別検索（cardType）
-  - レベル検索（level）
-  - 攻撃力・守備力検索（atk/def）
-  - テキスト検索（description）
-  - モンスタータイプ検索（monsterTypes）
-  - 魔法・罠タイプ検索（spellEffectType/trapEffectType）
-  - リンクマーカー検索（linkMarkers）
-  - ソート機能（ORDER BY）
+（変更内容をここに記載）
 
 ## Bug Fixes
 
-- `src/worker.ts`の`searchCardsExtended`関数で同じ条件が3回重複していたバグを修正
-- `rust/scripts/import-cards.ts`でlevelValueとsupplementInfoの読み込み修正
-- **Worker API レスポンスフォーマット修正**
-  - データベースのスネークケース（`card_id`, `description`等）からキャメルケース（`cardId`, `text`等）への変換を実装
-  - 全APIエンドポイントで`mapCardDbToApi`関数を使用してレスポンスを正規化
-  - TypeScript型定義との整合性を確保
-- **データ保存場所の cwd フォールバックを廃止**
-  - `getWorkDir()`が`~/.local/ygo-search/`未存在時にカレントディレクトリへフォールバックしていたが、`initWorkDir()`が未呼び出しで同ディレクトリが自動作成されず、`update`実行のたび実行場所に`data/`が作られるバグだった
-  - フォールバックを削除し、データは常に`~/.local/ygo-search/`に固定（`YGO_SEARCH_WORKDIR`で上書き可）
-  - `update`実行時に`initWorkDir()`を呼び`~/.local/ygo-search/`（`data/tsv`, `data/vector`, `tmp`）を自動作成するよう修正
+（変更内容をここに記載）
 
 ## Changes
 
-- **セキュリティ改善**
-  - 単一マスターキーからユーザーごとのAPIキー管理へ移行
-  - APIエンドポイント数: 18個 → 22個（APIキー管理4個追加）
-  - 認証方式の強化
-    - マスターキー: 全ての権限（管理者用）
-    - ユーザーAPIキー: スコープとレート制限でアクセス制御
-  - 監査ログによる全APIリクエストの追跡
+（変更内容をここに記載）
 
 ## Performance
 
@@ -74,22 +26,7 @@
 
 ## Internal Improvements
 
-- **テスト追加**
-  - 認証機能のユニットテスト（`tests/unit/auth.test.ts`）- 7件
-  - APIキー管理のE2Eテスト（`tests/e2e/api-keys.test.ts`）- 9件
-- D1データベースへのバッチインポート機能実装
-  - TSVファイルからSQLへの変換処理
-  - 1000件ずつの分割バッチ処理
-  - 大量データ（13,809件）のインポート対応
-  - 全カラム（race、level、atk、def、description等）のフルデータインポート完了
-  - import-cards.tsの出力先を`./tmp/`に変更
-- FAQ関連のインポートスクリプト追加
-  - `import-remaining-faqs.ts`: 残りのFAQインポート
-  - `import-rule-faqs.ts`: ルールFAQインポート
-  - `rebuild-faq-card-references.ts`: FAQとカードの参照再構築
-- スキーマ更新
-  - カードテーブルに追加カラム（race、monsterTypes、spellEffectType、trapEffectType、linkMarkers、linkValue）
-  - APIキーテーブル追加（api_keys、api_logs）
+（変更内容をここに記載）
 
 ## Known Issues
 

--- a/docs/changelog/v1.5.0.md
+++ b/docs/changelog/v1.5.0.md
@@ -1,0 +1,150 @@
+# v1.5.0 (2026-07-25)
+
+## New Features
+
+- **APIキー管理システムの実装**
+  - ユーザーごとのAPIキー発行・管理機能
+  - APIキー管理エンドポイント（4個）
+    - `POST /api/keys` - APIキー発行（管理者のみ）
+    - `GET /api/keys` - APIキー一覧取得
+    - `DELETE /api/keys/:id` - APIキー無効化
+    - `GET /api/keys/logs` - API使用ログ取得
+  - D1データベーステーブル追加
+    - `api_keys` - APIキー情報（ユーザーID、スコープ、レート制限、有効期限）
+    - `api_logs` - 監査ログ（エンドポイント、メソッド、ステータス、IPアドレス等）
+  - 認証ミドルウェア拡張
+    - マスターキー OR ユーザーAPIキーの両対応
+    - 有効期限チェック
+    - スコープ情報取得
+  - 監査ログ機能
+    - 全APIリクエストを自動記録
+    - ユーザーAPIキー使用時のみログ記録
+- Cloudflare Workers API実装
+  - カード検索エンドポイント (`/api/cards/search`)
+  - FAQ検索エンドポイント (`/api/faqs/search`)
+  - セマンティック検索エンドポイント（カード・FAQ）
+  - 統計情報エンドポイント (`/api/stats`)
+  - レート制限機能（60リクエスト/分）
+  - キャッシュ機能（1時間TTL）
+- カード検索機能の実装（Phase 0完了）
+  - 種族検索（race）
+  - カード種別検索（cardType）
+  - レベル検索（level）
+  - 攻撃力・守備力検索（atk/def）
+  - テキスト検索（description）
+  - モンスタータイプ検索（monsterTypes）
+  - 魔法・罠タイプ検索（spellEffectType/trapEffectType）
+  - リンクマーカー検索（linkMarkers）
+  - ソート機能（ORDER BY）
+- **Rust SDK (crates/ygo-search) の新設** (TASK-5, TASK-8, TASK-9, TASK-11, TASK-12, TASK-19)
+  - TS SDK と機能パリティを持つ Rust 実装を新設
+  - 利用用途に応じた Cargo feature 分割: `default`（コア: 型定義・normalize・パターン抽出）/ `fs`（TSV 読込・キャッシュ・フィルタエンジン・seek/pipeline）/ `format`（JSON/JSONC/JSONL/YAML 変換）/ `vector-search`（lancedb によるベクトル検索）/ `vector-index`（embedding 計算を含むインデックス構築）/ `vector`（`vector-search` + `vector-index` の合成）
+  - lib.rs で feature gate をコンパイル時に排他制御し、wasm32 環境で `fs`/`format`/`vector-search`/`vector-index` が有効な場合は `compile_error!` で即座に検知
+- **カード型・FAQ型・Options型の豊富化（TS 公開型との完全パリティ）** (TASK-8, TASK-9)
+  - Card DTO を TS 公開型と完全一致するよう実装し、従来の `search::Card`（3フィールド）から `types::card::Card`（全フィールド）へ一本化
+  - FAQ 拡張型（FAQRecord/CardReference/FAQWithCards/FAQSearchResult/FAQIndexEntry/FAQIndex）と全 Options/Params 型（SearchMode/SearchCardsParams/SearchFAQParams/ExtractOptions/JudgeAndReplaceOptions/SeekCardsOptions）を実装
+- **フォーマット変換機能（format feature）** (TASK-10, TASK-14)
+  - JSON/JSONC/JSONL/YAML の検出・パース・出力を実装（TS `src/lib/format-converter.ts` と同等）
+  - ファイル単位の変換と、JSON/YAML/JSONL/TSV/CSV から JSONL への変換を提供
+- **汎用フィルタエンジンと TS 互換ラッパ API（fs feature）** (TASK-11, TASK-12, TASK-13)
+  - TSV 読込・モジュール級キャッシュの基盤を実装
+  - filter/cols/mode/includeRuby/wildcard/否定句 をサポートする汎用フィルタエンジンと、search_cards/search_faq/load_faq_index/get_cards_by_ids/extract_card_references の TS 互換ラッパを提供
+  - seek_cards（max/random/range/all 抽出、rand=0.8 で重複なしランダム抽出）と extract_and_search_cards / judge_and_replace パイプラインを実装
+- **ベクトル検索機能（vector-search / vector-index feature）** (TASK-16, TASK-17, TASK-18)
+  - lancedb を用いた接続・テーブル一覧・検索を実装。where 式は文字列連結ではなく式ビルダーで構築し、識別子ホワイトリスト検証付きで安全化
+  - ort + tokenizers による e5-small モデル推論で embedding を生成（TS と同一の mean pooling + L2 正規化 + float32）
+  - index_from_jsonl / create_index によるインデックス構築（バッチ処理、metadata 推論で Arrow Struct を構築）
+- **Rust Workers adapter (crates/ygo-search-workers) の実装** (TASK-22)
+  - core crate の normalize/search API を参照する Workers ハンドラ（cdylib adapter）を実装
+  - POST /api/normalize, /api/patterns/extract, /api/patterns/replace, /api/search/cards, /api/search/faqs の5エンドポイントを追加（camelCase シリアライズ対応）
+  - 既存のワイルドカード(*)検索バグ（未変換 query を bind していた）を修正し TS 版と同等ロジックに統合
+
+## Bug Fixes
+
+- `src/worker.ts`の`searchCardsExtended`関数で同じ条件が3回重複していたバグを修正
+- `rust/scripts/import-cards.ts`でlevelValueとsupplementInfoの読み込み修正
+- **Worker API レスポンスフォーマット修正**
+  - データベースのスネークケース（`card_id`, `description`等）からキャメルケース（`cardId`, `text`等）への変換を実装
+  - 全APIエンドポイントで`mapCardDbToApi`関数を使用してレスポンスを正規化
+  - TypeScript型定義との整合性を確保
+- **データ保存場所の cwd フォールバックを廃止**
+  - `getWorkDir()`が`~/.local/ygo-search/`未存在時にカレントディレクトリへフォールバックしていたが、`initWorkDir()`が未呼び出しで同ディレクトリが自動作成されず、`update`実行のたび実行場所に`data/`が作られるバグだった
+  - フォールバックを削除し、データは常に`~/.local/ygo-search/`に固定（`YGO_SEARCH_WORKDIR`で上書き可）
+  - `update`実行時に`initWorkDir()`を呼び`~/.local/ygo-search/`（`data/tsv`, `data/vector`, `tmp`）を自動作成するよう修正
+- **CLI --help/-h の位置依存バグを修正** (TASK-29)
+  - `src/cli/ygo_search.ts` を commander ベースに全面書き換え、--help/-h が引数の位置に関わらず正しく動作するよう構造的に解消
+  - 特に `vector setup --help` が本物のインデックス再構築を誤実行していた重大バグを解消
+  - 今後のサブコマンド追加時の書き忘れも構造的に防止。既存の日本語ヘルプ文言・後方互換（`card` 省略時フォールバック等）も完全保持
+- **filter.rs の否定句検出でシングルクォート/バックティック未対応を修正** (TASK-30, PR#56)
+  - `cond_str.contains("-\"")` のみのチェックを `cond_str.contains('-')` に変更し、`-'...'` / `` -`...` `` 形式の否定句も正しく検出
+- **JSONL パースでの Windows 改行コード(\r\n) 非対応を修正** (TASK-31, TASK-32, TASK-33, PR#56)
+  - format/mod.rs・jsonl.rs（parse_delimited, convert_generic_to_jsonl）の `split('\n')` を `lines()` に変更し、\r\n を適切に処理
+- **indexer.rs で空 metadata の場合も metadata 列を保持** (TASK-35, PR#57)
+  - StructBuilder により全行分の空フィールド StructArray を構築し、全レコードの metadata が省略/空の場合でも metadata 列を必ず保持
+  - searcher.rs で null/欠損 metadata を `{}` に正規化（TS の `data.metadata || {}` とパリティ）
+
+## Changes
+
+- **セキュリティ改善**
+  - 単一マスターキーからユーザーごとのAPIキー管理へ移行
+  - APIエンドポイント数: 18個 → 22個（APIキー管理4個追加）
+  - 認証方式の強化
+    - マスターキー: 全ての権限（管理者用）
+    - ユーザーAPIキー: スコープとレート制限でアクセス制御
+  - 監査ログによる全APIリクエストの追跡
+- **パッケージマネージャを pnpm へ移行** (TASK-2)
+  - bun から pnpm@10.26.2 へ移行。npm publish は `pnpm publish` で実行
+  - CI matrix[20/22]は維持、onlyBuiltDependencies(lancedb/swc/xenova/esbuild/workerd)を dev の依存に合わせ適正化
+
+## Performance
+
+（変更内容をここに記載）
+
+## Refactoring
+
+- **Rust SDK 全体で cargo fmt / clippy -D warnings をクリーン化** (TASK-26)
+  - PatternExtractor に `Default` impl を追加（clippy::new_without_default）、不要な `into_iter()` を削除（clippy::useless_conversion）、`assert!(len > 0)` を `!is_empty()` に変更（clippy::len_zero）
+- **jsonl.rs の map_or → is_some_and で新 clippy lint に対応** (TASK-34, PR#56)
+  - `map_or(false, ...)` を `is_some_and(...)` に変更し、unnecessary_map_or lint に対応
+
+## Repository Management
+
+- **Rust ワークスペース構成への移行** (TASK-5)
+  - `rust/` 単一 crate を `crates/ygo-search`（core, rlib）+ `crates/ygo-search-workers`（adapter, cdylib+rlib）の2 crate 構成へ物理分割
+  - core は worker 0.4 非依存の純粋ロジック（regex のみ依存）、workers crate は core に path 依存。旧 rlib 利用者向け互換 re-export も経過措置で保持
+- **Rust 向け CI feature マトリクスを新設** (TASK-19)
+  - `rust-toolchain.toml`（stable + wasm32-unknown-unknown target）を新設
+  - `rust-ci.yml` に3ジョブを追加: native-matrix（default/fs/format/fs+format/vector の各 feature で check+test）/ wasm32-success（core と workers crate が wasm32 でビルド成功することを検証）/ wasm32-compile-fail（native-only feature が有効な場合はコンパイル失敗することを検証）
+  - 併せて CICD.md（rust-ci.yml セクション追加・Node 20/22・npm→pnpm・badge URL 修正・絵文字除去）と docs/README.md を更新
+
+## Internal Improvements
+
+- **テスト追加**
+  - 認証機能のユニットテスト（`tests/unit/auth.test.ts`）- 7件
+  - APIキー管理のE2Eテスト（`tests/e2e/api-keys.test.ts`）- 9件
+- D1データベースへのバッチインポート機能実装
+  - TSVファイルからSQLへの変換処理
+  - 1000件ずつの分割バッチ処理
+  - 大量データ（13,809件）のインポート対応
+  - 全カラム（race、level、atk、def、description等）のフルデータインポート完了
+  - import-cards.tsの出力先を`./tmp/`に変更
+- FAQ関連のインポートスクリプト追加
+  - `import-remaining-faqs.ts`: 残りのFAQインポート
+  - `import-rule-faqs.ts`: ルールFAQインポート
+  - `rebuild-faq-card-references.ts`: FAQとカードの参照再構築
+- スキーマ更新
+  - カードテーブルに追加カラム（race、monsterTypes、spellEffectType、trapEffectType、linkMarkers、linkValue）
+  - APIキーテーブル追加（api_keys、api_logs）
+- **API/TSV 契約の固定と searchCards 仕様確定** (TASK-6, TASK-7)
+  - TS公開型面（Card DTO + 9 enum + FAQ 型群 + Options 型群）と TSV 全カラム（cards-all/detail-all/faq-all）を Rust serde DTO + fixture として凍結し、後続タスクの手戻りを防止
+  - TS 内部の SpellEffectType 不一致（`converter.ts: 'quickPlay'→'quick'`、速攻魔法の「速攻」欠落という潜在バグも解消）を修正し、searchCards の filter/cols/mode/includeRuby/wildcard/否定句 仕様を `docs/dev/m0-t3-searchcards-filter-spec.md` に文書化
+- **ベクトル機能の実現性検証（PoC）** (TASK-15)
+  - ort + tokenizers による e5-small 推論が TS と一致することと、lancedb 0.31 が Rust/TS 双方向で相互運用可能であることを実証し、本実装（M3-T1〜T3）の実現性を確認
+- **ONNX モデル整合性 hash pinning の導入** (TASK-28, PR#57)
+  - model.onnx 不整合の根本原因を特定（非量子化 model.onnx と量子化 golden.json のクロスモデル差と判明、破損は否定）
+  - `src/vector/integrity.rs` で SHA256 照合・期待 hash 表（`models.sha256`）をバイナリ埋め込み・ロード前 fail-fast 検証を実装
+  - モデル配布を revision 761b726d に pin し、`YGO_SEARCH_STRICT_MODEL_VERIFY` / `YGO_SEARCH_SKIP_MODEL_VERIFY` 環境変数で動作制御可能。orchestration テスト7件を追加
+
+## Known Issues
+
+（変更内容をここに記載）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ygo-search",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "CLI tools for Yu-Gi-Oh card search with local database",
   "type": "module",
   "packageManager": "pnpm@10.26.2",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# ygo-search 共通 toolchain。
+# ローカル・CI で stable + wasm32 target を統一（rustup が自動適用・インストール）。
+# rust-ci.yml の wasm32 検証と workers crate ビルドで必要。
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"

--- a/tests/README.md
+++ b/tests/README.md
@@ -210,6 +210,8 @@ cargo test -p ygo-search --features vector-search   # model 不要テストは�
 cargo test --workspace                               # workers crate 含む全体
 ```
 
+CI（`rust-ci.yml`）では default/fs/format/fs+format/vector 各 feature の check+test と、wasm32 での native-only feature 排他検証（compile_error!）をマトリクス実行。詳細は `.github/CICD.md` 参照。
+
 ### 特定のテストファイルのみ実行
 ```bash
 npx vitest run tests/unit/pattern-extraction.test.ts

--- a/tests/README.md
+++ b/tests/README.md
@@ -210,7 +210,7 @@ cargo test -p ygo-search --features vector-search   # model 不要テストは�
 cargo test --workspace                               # workers crate 含む全体
 ```
 
-CI（`rust-ci.yml`）では default/fs/format/fs+format/vector 各 feature の check+test と、wasm32 での native-only feature 排他検証（compile_error!）をマトリクス実行。詳細は `.github/CICD.md` 参照。
+CI（`rust-ci.yml`）では default/fs/format/fs+format/vector-search/vector 各 feature の check+test と、wasm32 での native-only feature 排他検証（compile_error! メッセージまたは既知の getrandom 依存エラーの許可リストで厳格検証）をマトリクス実行。詳細は `.github/CICD.md` 参照。
 
 ### 特定のテストファイルのみ実行
 ```bash


### PR DESCRIPTION
## 変更内容

### TASK-19(M4-T1) CI featureマトリクス
- lib.rs: wasm32 compile_error! を4ブロック化(fs/format/vector-search/vector-index)
- rust-toolchain.toml新設(stable + wasm32-unknown-unknown)
- rust-ci.yml新設(3ジョブ: native-matrix/wasm32-success/wasm32-compile-fail)
- CICD.md/docs更新(rust-ci.yml記載・mcp_new→dev・Node18/20→20/22・npm→pnpm・badge修正・絵文字除去)

### Release v1.5.0
- CHANGELOGにRust SDK全体(M0-M5 + TASK-28等27タスク)を記載
- package.json 1.4.0 -> 1.5.0
- Rust SDK(crates/*)は独立ライブラリのため0.1.0維持

## テスト
- [x] native feature マトリクス(default/fs/format/fs+format/vector) check+test green
- [x] wasm32-success(core + workers crate) check OK
- [x] wasm32 compile-fail(fs/format/vector-search 実証・check_msg フラグで実証ベース調整)
- [x] docs/tests更新完了(update-docs/update-tests)

## 関連タスク
- TASK-19 (M4-T1) CI featureマトリクス
- v1.5.0 リリース(27タスク: TASK-2,5-19,22,25,26,28,29-35)

## 確認事項
- [ ] コードレビュー依頼済み
- [ ] CIパス確認

## リリースフロー（マージ後）
このPRがdevにマージされた後、dev -> mainのPRを作成し、mainマージ後にタグv1.5.0 push + GitHubリリース作成を行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)